### PR TITLE
Add a modal for each team including detailed results

### DIFF
--- a/assets/results_template/script.js
+++ b/assets/results_template/script.js
@@ -243,7 +243,7 @@ $(document).ready(function(){
   $("div#medal-filter input").change(function() {
       let medal_number = $(this).attr("id").slice("medal".length);
       let medals = $("td[data-points='" + medal_number + "'] div")
-      
+
       if ($(this).prop("checked")) {
         medals.removeAttr("style"); // default state is 'highlighted'
       } else {
@@ -251,9 +251,25 @@ $(document).ready(function(){
       }
   });
 
-  // Populate Team Detail table
+  // Cribbed from https://git.io/Je8kk
+  function getOrdinal(n) {
+    let s = ["th", "st", "nd", "rd"],
+    v = n%100;
+    return n+(s[(v-20)%10]||s[v]||s[0]);
+  }
+
+  // Populate Team Detail table and rest of modal
   $("td.number a").on("click", function() {
     let source_row = $(this).closest("tr");
+    let points = source_row.children("td.total-points").text();
+    let place = source_row.children("td.rank").attr("data-points");
+
+    $("div#team-detail span#number").html($(this).text());
+    $("div#team-detail span#points").html(points);
+    $("div#team-detail span#place").html(getOrdinal(place));
+    $("div#team-detail span#team").html(source_row.attr("data-team-name"));
+    $("div#team-detail span#school").html(source_row.attr("data-school"));
+
     let table_rows = $("div#team-detail table tbody").children();
     $.each(source_row.children("td.event-points"), function (index, td) {
       let dest_row = table_rows.eq(index);
@@ -262,7 +278,6 @@ $(document).ready(function(){
       let place = data_place > 999000 ? "n/a" : data_place
       dest_row.children().eq(2).html(place);
       dest_row.children().eq(3).html($(td).attr("data-notes"));
-      console.log(dest_row);
     });
   });
 

--- a/assets/results_template/script.js
+++ b/assets/results_template/script.js
@@ -281,6 +281,12 @@ $(document).ready(function(){
     });
   });
 
+  // Give small message about other results not yet being implemented
+  $("#other-results").on("click", function(e) {
+    e.preventDefault();
+    alert("Not yet implemented, coming soon™ 🎉")
+  });
+
   // Enable popovers for further explanation of badge abbrevs
   $(function () {
     $('[data-toggle="popover"]').popover()

--- a/assets/results_template/script.js
+++ b/assets/results_template/script.js
@@ -251,6 +251,18 @@ $(document).ready(function(){
       }
   });
 
+  // Populate Team Detail table
+  $("td.number a").on("click", function() {
+    let source_row = $(this).closest("tr");
+    let table_rows = $("div#team-detail table tbody").children();
+    $.each(source_row.children("td.event-points"), function (index, td) {
+      let dest_row = table_rows.eq(index);
+      dest_row.children().eq(1).html($(td).attr("data-place"));
+      dest_row.children().eq(2).html($(td).attr("data-points"));
+      console.log(dest_row);
+    });
+  });
+
   // Enable popovers for further explanation of badge abbrevs
   $(function () {
     $('[data-toggle="popover"]').popover()

--- a/assets/results_template/script.js
+++ b/assets/results_template/script.js
@@ -257,8 +257,11 @@ $(document).ready(function(){
     let table_rows = $("div#team-detail table tbody").children();
     $.each(source_row.children("td.event-points"), function (index, td) {
       let dest_row = table_rows.eq(index);
-      dest_row.children().eq(1).html($(td).attr("data-place"));
-      dest_row.children().eq(2).html($(td).attr("data-points"));
+      dest_row.children().eq(1).html($(td).attr("data-true-points"));
+      let data_place = $(td).attr("data-place");
+      let place = data_place > 999000 ? "n/a" : data_place
+      dest_row.children().eq(2).html(place);
+      dest_row.children().eq(3).html($(td).attr("data-notes"));
       console.log(dest_row);
     });
   });

--- a/assets/results_template/style.scss
+++ b/assets/results_template/style.scss
@@ -316,6 +316,31 @@ div.results-classic-footnotes {
   }
 }
 
+div#team-detail {
+  table {
+    table-layout: fixed;
+    width: 1em;
+
+    @include media-breakpoint-down(xs) {
+      font-size: 0.8em;
+    }
+
+    th.event { width: 16.5em; }
+    th.points { width: 3em; }
+    th.place { width: 6em; }
+    th.notes { width: 11em; }
+
+    th.points, th.place, td.points, td.place{
+      text-align: center;
+    }
+
+    td {
+      height: 2em;
+      white-space: nowrap;
+    }
+  }
+}
+
 div#print-instructions {
   ul {
     padding-left: 1.5em;

--- a/assets/results_template/style.scss
+++ b/assets/results_template/style.scss
@@ -317,6 +317,11 @@ div.results-classic-footnotes {
 }
 
 div#team-detail {
+  div.modal-dialog {
+    max-width: 42rem;
+    width: calc(100% - 1rem * 2);
+  }
+
   table {
     table-layout: fixed;
     width: 1em;
@@ -328,7 +333,7 @@ div#team-detail {
     th.event { width: 16.5em; }
     th.points { width: 3em; }
     th.place { width: 6em; }
-    th.notes { width: 11em; }
+    th.notes { width: 19em; }
 
     th.points, th.place, td.points, td.place{
       text-align: center;

--- a/config.rb
+++ b/config.rb
@@ -193,6 +193,13 @@ helpers do
           .sub('Secondary School', 'Secondary')
   end
 
+  def full_team_name(team)
+    location = if team.city then "(#{team.city}, #{team.state})"
+               else              "(#{team.state})"
+               end
+    [team.school, team.suffix, location].join(' ')
+  end
+
   def search_string(interpreter)
     t = interpreter.tournament
     words = [

--- a/config.rb
+++ b/config.rb
@@ -193,6 +193,13 @@ helpers do
           .sub('Secondary School', 'Secondary')
   end
 
+  def full_school_name(team)
+    location = if team.city then "(#{team.city}, #{team.state})"
+               else              "(#{team.state})"
+               end
+    [team.school, location].join(' ')
+  end
+
   def full_team_name(team)
     location = if team.city then "(#{team.city}, #{team.state})"
                else              "(#{team.state})"

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -130,7 +130,9 @@ custom_colors: true
 </thead>
 <tbody>
 <% i.teams.each do |tm| %>
-  <tr data-team-number="<%= tm.number %>">
+  <tr data-team-number="<%= tm.number %>"
+      data-school="<%= tm.school %>"
+      data-team-name="<%= full_team_name(tm) %>">
     <td class="number">
       <a href="#" data-toggle="modal" data-target="#team-detail">
         <%= tm.number %>
@@ -364,7 +366,7 @@ custom_colors: true
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="team-detail-label">
-          Team Detail
+          Details for Team <span id="number">[number]</span>
         </h5>
         <button type="button" class="close" data-dismiss="modal"
                 aria-label="Close">
@@ -406,7 +408,7 @@ custom_colors: true
         <hr>
         <h6>Other Results (Coming Soon™)</h6>
         <p><a href="#" id="other-results">
-          View <span id="school">[school]</span>'s other tournament results
+          View other tournament results for <span id="school">[school]</span>
         </a></p>
       </div>
       <div class="modal-footer">

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -134,7 +134,8 @@ custom_colors: true
       data-school="<%= tm.school %>"
       data-team-name="<%= full_team_name(tm) %>">
     <td class="number">
-      <a href="#" data-toggle="modal" data-target="#team-detail">
+      <a href="?team=<%= tm.number %>"
+         data-toggle="modal" data-target="#team-detail">
         <%= tm.number %>
       </a>
     </td>

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -131,7 +131,7 @@ custom_colors: true
 <tbody>
 <% i.teams.each do |tm| %>
   <tr data-team-number="<%= tm.number %>"
-      data-school="<%= tm.school %>"
+      data-school="<%= full_school_name(tm) %>"
       data-team-name="<%= full_team_name(tm) %>">
     <td class="number">
       <a href="?team=<%= tm.number %>"
@@ -406,7 +406,7 @@ custom_colors: true
         <hr>
         <h6>Other Results (Coming Soon™)</h6>
         <p><a href="#" id="other-results">
-          View other tournament results for <span id="school">[school]</span>
+          View results for <span id="school">[school]</span> in other tournaments
         </a></p>
       </div>
       <div class="modal-footer">

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -376,10 +376,7 @@ custom_colors: true
       <div class="modal-body">
         <h6>Summary</h6>
         <p><span id="team">[team]</span> placed <span id="place">[place]</span>
-        overall with a total score of <span id="points">[points]</span> points at the
-        <%= i.tournament.date.year %> <%= tournament_title(i.tournament) %>
-        (Division <%= i.tournament.division %>)
-        held on <%= i.tournament.date.strftime('%A, %B %-d, %Y') %>.</p>
+        overall with a total score of <span id="points">[points]</span> points.
         <hr>
         <div class="table-responsive-md">
         <table class="table-striped">

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -168,6 +168,25 @@ custom_colors: true
     <% unknown = placing.unknown? %>
     <% exempt = placing.exempt? %>
     <td class="event-points"
+        data-true-points="<%= placing.points %>"
+        data-notes="<%=
+          [
+            ('trial event' if placing.event.trial?),
+            ('trialed event' if placing.event.trialed?),
+            ('disqualified' if placing.disqualified?),
+            ('did not participate' if placing.did_not_participate?),
+            ('participation points only' if placing.participation_only?),
+            ('tie' if placing.tie?),
+            ('exempt' if placing.exempt?),
+            ('unknown place' if placing.unknown?),
+            ('placed behind exhibition team'\
+             if placing.considered_for_team_points? && placing.place &&
+                placing.place - placing.points == 1),
+            ('placed behind exhibition teams'\
+             if placing.considered_for_team_points? && placing.place &&
+                placing.place - placing.points > 1),
+          ].compact.join(', ').capitalize
+        %>"
         data-points="<%= unknown ? '??' : points %>"
         data-place="<%= place ? place : 999000 + points %>">
       <div><%= unknown ? '??' : points %><%= '<sup>⬨</sup>' if exempt %></div>
@@ -360,7 +379,7 @@ custom_colors: true
         (Division <%= i.tournament.division %>)
         held on <%= i.tournament.date.strftime('%A, %B %-d, %Y') %>.</p>
         <hr>
-        <div class="table-responsive-sm">
+        <div class="table-responsive-md">
         <table class="table-striped">
         <thead>
           <tr>
@@ -375,11 +394,6 @@ custom_colors: true
           <tr>
             <td class="event">
               <%= e.name %>
-              <% if e.trial? %>
-                (Trial)
-              <% elsif e.trialed? %>
-                (Trialed)
-              <% end %>
             </td>
             <td class="points"></td>
             <td class="place"></td>

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -354,7 +354,11 @@ custom_colors: true
       </div>
       <div class="modal-body">
         <h6>Summary</h6>
-        <p>[team] placed [place] overall with a total score of [points] points at [tournament] on [date]</p>
+        <p><span id="team">[team]</span> placed <span id="place">[place]</span>
+        overall with a total score of <span id="points">[points]</span> points at the
+        <%= i.tournament.date.year %> <%= tournament_title(i.tournament) %>
+        (Division <%= i.tournament.division %>)
+        held on <%= i.tournament.date.strftime('%A, %B %-d, %Y') %>.</p>
         <hr>
         <div class="table-responsive-sm">
         <table class="table-striped">
@@ -387,7 +391,9 @@ custom_colors: true
         </div>
         <hr>
         <h6>Other Results (Coming Soon™)</h6>
-        <p><a href="#">View [school]'s other tournament results</a></p>
+        <p><a href="#" id="other-results">
+          View <span id="school">[school]</span>'s other tournament results
+        </a></p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">

--- a/source/results/template.html.erb
+++ b/source/results/template.html.erb
@@ -131,7 +131,11 @@ custom_colors: true
 <tbody>
 <% i.teams.each do |tm| %>
   <tr data-team-number="<%= tm.number %>">
-    <td class="number"><%= tm.number %></td>
+    <td class="number">
+      <a href="#" data-toggle="modal" data-target="#team-detail">
+        <%= tm.number %>
+      </a>
+    </td>
     <td class="team">
       <%= format_school(tm) %>
       <%= tm.suffix %>
@@ -331,6 +335,64 @@ custom_colors: true
            href="../data/<%= File.basename(current_page.path, '.html') + '.yaml' %>">
           Download
         </a>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal" id="team-detail" tabindex="-1" role="dialog"
+     aria-labelledby="team-detail-label" aria-hidden="true">
+  <div class="modal-dialog" role="form">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="team-detail-label">
+          Team Detail
+        </h5>
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="Close">
+          <span aria-hidden="true" style="vertical-align: super">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <h6>Summary</h6>
+        <p>[team] placed [place] overall with a total score of [points] points at [tournament] on [date]</p>
+        <hr>
+        <div class="table-responsive-sm">
+        <table class="table-striped">
+        <thead>
+          <tr>
+            <th class="event">Event</th>
+            <th class="points">Points</th>
+            <th class="place">Place</th>
+            <th class="notes">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% i.events.each do |e| %>
+          <tr>
+            <td class="event">
+              <%= e.name %>
+              <% if e.trial? %>
+                (Trial)
+              <% elsif e.trialed? %>
+                (Trialed)
+              <% end %>
+            </td>
+            <td class="points"></td>
+            <td class="place"></td>
+            <td class="notes"></td>
+          </tr>
+        <% end %>
+        </tbody>
+        </table>
+        </div>
+        <hr>
+        <h6>Other Results (Coming Soon™)</h6>
+        <p><a href="#">View [school]'s other tournament results</a></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+          Close
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fairly sparse for now, but good starting point if we want need a place for more info in the future. Only took a month = P.

### Potential TODOs

- make modal accessible just by clicking anywhere in the school or team number column
- add a table for team penalties (and rationale behind them, will require changes in SciolyFF)