### PR TITLE
Add Bay Area Regionals 2020

### DIFF
--- a/data/2019-03-02_nCA_bay_area_regional_b.yaml
+++ b/data/2019-03-02_nCA_bay_area_regional_b.yaml
@@ -1,7 +1,7 @@
 ---
 Tournament:
   name: Bay Area Regional Science Olympiad Tournament
-  short name: Bay Area Regional
+  short name: BARSO
   location: California State University, East Bay
   state: nCA
   level: Regionals

--- a/data/2020-02-29_nCA_bay_area_regional_b.yaml
+++ b/data/2020-02-29_nCA_bay_area_regional_b.yaml
@@ -1,0 +1,2292 @@
+---
+Tournament:
+  name: Bay Area Regional Science Olympiad Tournament
+  location: California State University East Bay
+  state: nCA
+  level: Regionals
+  division: B
+  year: 2020
+  date: 2020-02-29
+Events:
+- name: Anatomy and Physiology
+- name: Boomilever
+- name: Circuit Lab
+- name: Crime Busters
+- name: Density Lab
+- name: Disease Detectives
+- name: Dynamic Planet
+- name: Elastic Launched Glider
+- name: Experimental Design
+- name: Food Science
+- name: Fossils
+- name: Game On
+- name: Heredity
+- name: Machines
+- name: Meteorology
+- name: Mission Possible
+- name: Mousetrap Vehicle
+- name: Ornithology
+- name: Ping Pong Parachute
+  trialed: true
+- name: Reach for the Stars
+- name: Road Scholar
+- name: Water Quality
+- name: Write It Do It
+Teams:
+- number: 1
+  school: Canyon Middle School
+  suffix: Gold
+  state: CA
+- number: 2
+  school: Canyon Middle School
+  suffix: Red
+  state: CA
+- number: 3
+  school: Canyon Middle School
+  suffix: White
+  state: CA
+- number: 4
+  school: Christensen Middle School
+  suffix: Blue
+  state: CA
+- number: 5
+  school: Christensen Middle School
+  suffix: Gold
+  state: CA
+- number: 6
+  school: Christensen Middle School
+  suffix: White
+  state: CA
+- number: 7
+  school: Thornton Junior High School
+  suffix: Black
+  state: CA
+- number: 8
+  school: Thornton Junior High School
+  suffix: Blue
+  state: CA
+- number: 9
+  school: Thornton Junior High School
+  suffix: Yellow
+  state: CA
+- number: 10
+  school: Harvest Park Middle School
+  state: CA
+- number: 11
+  school: Albany Middle School
+  suffix: Gold
+  state: CA
+- number: 12
+  school: Albany Middle School
+  suffix: Black
+  state: CA
+- number: 13
+  school: Ardenwood Elementary School
+  suffix: Sciensteins
+  state: CA
+- number: 14
+  school: Ardenwood Elementary School
+  suffix: Atomic Dragons
+  state: CA
+- number: 15
+  school: Bowditch Middle School
+  suffix: Blue
+  state: CA
+- number: 16
+  school: Bowditch Middle School
+  suffix: Gold
+  state: CA
+- number: 17
+  school: Creekside Middle School
+  suffix: Cobalt
+  state: CA
+- number: 18
+  school: Creekside Middle School
+  suffix: Gold
+  state: CA
+- number: 19
+  school: BASIS Independent Fremont
+  state: CA
+- number: 20
+  school: Centerville Junior High School
+  suffix: Black
+  state: CA
+- number: 21
+  school: East Bay Innovation Academy
+  suffix: Blue
+  state: CA
+- number: 22
+  school: East Bay Innovation Academy
+  suffix: Green
+  state: CA
+- number: 23
+  school: Carmel Middle School
+  state: CA
+- number: 24
+  school: Fallon Middle School
+  state: CA
+- number: 25
+  school: Fred E. Weibel Elementary School
+  state: CA
+- number: 26
+  school: Hopkins Junior High School
+  state: CA
+- number: 27
+  school: Willie L. Brown Jr. Middle School
+  state: CA
+- number: 28
+  school: Warm Springs Elementary School
+  suffix: Jade
+  state: CA
+- number: 29
+  school: Warm Springs Elementary School
+  suffix: Sapphire
+  state: CA
+- number: 30
+  school: Warm Springs Elementary School
+  suffix: Ruby
+  state: CA
+- number: 31
+  school: Centerville Junior High School
+  suffix: Red
+  state: CA
+Placings:
+- team: 1
+  event: Anatomy and Physiology
+  place: 18
+- team: 1
+  event: Boomilever
+  place: 14
+- team: 1
+  event: Circuit Lab
+  place: 19
+- team: 1
+  event: Crime Busters
+  place: 3
+- team: 1
+  event: Density Lab
+  place: 23
+- team: 1
+  event: Disease Detectives
+  place: 16
+- team: 1
+  event: Dynamic Planet
+  place: 3
+- team: 1
+  event: Elastic Launched Glider
+  place: 6
+- team: 1
+  event: Experimental Design
+  place: 9
+- team: 1
+  event: Food Science
+  place: 20
+- team: 1
+  event: Fossils
+  place: 8
+- team: 1
+  event: Game On
+  place: 18
+- team: 1
+  event: Heredity
+  place: 24
+- team: 1
+  event: Machines
+  place: 20
+- team: 1
+  event: Meteorology
+  place: 16
+- team: 1
+  event: Mission Possible
+  place: 14
+- team: 1
+  event: Mousetrap Vehicle
+  place: 13
+- team: 1
+  event: Ornithology
+  place: 16
+- team: 1
+  event: Ping Pong Parachute
+  place: 6
+- team: 1
+  event: Reach for the Stars
+  place: 25
+- team: 1
+  event: Road Scholar
+  place: 10
+- team: 1
+  event: Water Quality
+  place: 13
+- team: 1
+  event: Write It Do It
+  place: 5
+- team: 2
+  event: Anatomy and Physiology
+  place: 22
+- team: 2
+  event: Boomilever
+  place: 10
+- team: 2
+  event: Circuit Lab
+  place: 18
+- team: 2
+  event: Crime Busters
+  place: 6
+- team: 2
+  event: Density Lab
+  place: 13
+- team: 2
+  event: Disease Detectives
+  place: 12
+- team: 2
+  event: Dynamic Planet
+  place: 12
+- team: 2
+  event: Elastic Launched Glider
+  place: 3
+- team: 2
+  event: Experimental Design
+  place: 15
+- team: 2
+  event: Food Science
+  place: 22
+- team: 2
+  event: Fossils
+  place: 9
+- team: 2
+  event: Game On
+  place: 15
+- team: 2
+  event: Heredity
+  place: 15
+- team: 2
+  event: Machines
+  place: 15
+- team: 2
+  event: Meteorology
+  place: 15
+- team: 2
+  event: Mission Possible
+  place: 5
+- team: 2
+  event: Mousetrap Vehicle
+  place: 2
+- team: 2
+  event: Ornithology
+  place: 7
+- team: 2
+  event: Ping Pong Parachute
+  place: 16
+- team: 2
+  event: Reach for the Stars
+  place: 10
+- team: 2
+  event: Road Scholar
+  place: 11
+- team: 2
+  event: Water Quality
+  place: 20
+- team: 2
+  event: Write It Do It
+  place: 8
+- team: 3
+  event: Anatomy and Physiology
+  place: 14
+- team: 3
+  event: Boomilever
+  place: 12
+- team: 3
+  event: Circuit Lab
+  place: 26
+- team: 3
+  event: Crime Busters
+  place: 14
+- team: 3
+  event: Density Lab
+  place: 18
+- team: 3
+  event: Disease Detectives
+  place: 13
+- team: 3
+  event: Dynamic Planet
+  place: 5
+- team: 3
+  event: Elastic Launched Glider
+  place: 7
+- team: 3
+  event: Experimental Design
+  place: 11
+- team: 3
+  event: Food Science
+  place: 16
+- team: 3
+  event: Fossils
+  place: 13
+- team: 3
+  event: Game On
+  place: 12
+- team: 3
+  event: Heredity
+  place: 17
+- team: 3
+  event: Machines
+  place: 19
+- team: 3
+  event: Meteorology
+  place: 7
+- team: 3
+  event: Mission Possible
+  place: 23
+- team: 3
+  event: Mousetrap Vehicle
+  place: 21
+- team: 3
+  event: Ornithology
+  place: 26
+- team: 3
+  event: Ping Pong Parachute
+  place: 10
+- team: 3
+  event: Reach for the Stars
+  place: 24
+- team: 3
+  event: Road Scholar
+  place: 16
+- team: 3
+  event: Water Quality
+  place: 22
+- team: 3
+  event: Write It Do It
+  place: 28
+- team: 4
+  event: Anatomy and Physiology
+  place: 5
+- team: 4
+  event: Boomilever
+  place: 5
+- team: 4
+  event: Circuit Lab
+  place: 17
+- team: 4
+  event: Crime Busters
+  place: 8
+- team: 4
+  event: Density Lab
+  place: 7
+- team: 4
+  event: Disease Detectives
+  place: 5
+- team: 4
+  event: Dynamic Planet
+  place: 25
+- team: 4
+  event: Elastic Launched Glider
+  place: 2
+- team: 4
+  event: Experimental Design
+  place: 6
+- team: 4
+  event: Food Science
+  place: 9
+- team: 4
+  event: Fossils
+  place: 17
+- team: 4
+  event: Game On
+  place: 6
+- team: 4
+  event: Heredity
+  place: 1
+- team: 4
+  event: Machines
+  place: 17
+- team: 4
+  event: Meteorology
+  place: 25
+- team: 4
+  event: Mission Possible
+  place: 3
+- team: 4
+  event: Mousetrap Vehicle
+  place: 12
+- team: 4
+  event: Ornithology
+  place: 1
+- team: 4
+  event: Ping Pong Parachute
+  place: 13
+- team: 4
+  event: Reach for the Stars
+  place: 7
+- team: 4
+  event: Road Scholar
+  place: 3
+- team: 4
+  event: Water Quality
+  place: 7
+- team: 4
+  event: Write It Do It
+  place: 6
+- team: 5
+  event: Anatomy and Physiology
+  place: 19
+- team: 5
+  event: Boomilever
+  place: 7
+- team: 5
+  event: Circuit Lab
+  place: 21
+- team: 5
+  event: Crime Busters
+  place: 20
+- team: 5
+  event: Density Lab
+  place: 14
+- team: 5
+  event: Disease Detectives
+  place: 24
+- team: 5
+  event: Dynamic Planet
+  place: 27
+- team: 5
+  event: Elastic Launched Glider
+  place: 4
+- team: 5
+  event: Experimental Design
+  place: 12
+- team: 5
+  event: Food Science
+  place: 21
+- team: 5
+  event: Fossils
+  place: 19
+- team: 5
+  event: Game On
+  place: 13
+- team: 5
+  event: Heredity
+  place: 29
+- team: 5
+  event: Machines
+  place: 14
+- team: 5
+  event: Meteorology
+  place: 21
+- team: 5
+  event: Mission Possible
+  place: 6
+- team: 5
+  event: Mousetrap Vehicle
+  place: 6
+- team: 5
+  event: Ornithology
+  place: 15
+- team: 5
+  event: Ping Pong Parachute
+  place: 21
+- team: 5
+  event: Reach for the Stars
+  place: 8
+- team: 5
+  event: Road Scholar
+  place: 13
+- team: 5
+  event: Water Quality
+  place: 3
+- team: 5
+  event: Write It Do It
+  place: 4
+- team: 6
+  event: Anatomy and Physiology
+  place: 15
+- team: 6
+  event: Boomilever
+  place: 9
+- team: 6
+  event: Circuit Lab
+  place: 13
+- team: 6
+  event: Crime Busters
+  place: 17
+- team: 6
+  event: Density Lab
+  place: 24
+- team: 6
+  event: Disease Detectives
+  place: 26
+- team: 6
+  event: Dynamic Planet
+  place: 23
+- team: 6
+  event: Elastic Launched Glider
+  place: 5
+- team: 6
+  event: Experimental Design
+  place: 24
+- team: 6
+  event: Food Science
+  place: 17
+- team: 6
+  event: Fossils
+  place: 16
+- team: 6
+  event: Game On
+  place: 28
+- team: 6
+  event: Heredity
+  place: 11
+- team: 6
+  event: Machines
+  place: 25
+- team: 6
+  event: Meteorology
+  place: 11
+- team: 6
+  event: Mission Possible
+  place: 12
+- team: 6
+  event: Mousetrap Vehicle
+  place: 14
+- team: 6
+  event: Ornithology
+  place: 11
+- team: 6
+  event: Ping Pong Parachute
+  place: 15
+- team: 6
+  event: Reach for the Stars
+  place: 26
+- team: 6
+  event: Road Scholar
+  place: 19
+- team: 6
+  event: Water Quality
+  place: 27
+- team: 6
+  event: Write It Do It
+  participated: false
+- team: 7
+  event: Anatomy and Physiology
+  place: 8
+- team: 7
+  event: Boomilever
+  place: 15
+- team: 7
+  event: Circuit Lab
+  place: 4
+- team: 7
+  event: Crime Busters
+  place: 24
+- team: 7
+  event: Density Lab
+  place: 12
+- team: 7
+  event: Disease Detectives
+  place: 3
+- team: 7
+  event: Dynamic Planet
+  place: 11
+- team: 7
+  event: Elastic Launched Glider
+  place: 19
+- team: 7
+  event: Experimental Design
+  place: 8
+- team: 7
+  event: Food Science
+  place: 5
+- team: 7
+  event: Fossils
+  place: 11
+- team: 7
+  event: Game On
+  place: 10
+- team: 7
+  event: Heredity
+  place: 8
+- team: 7
+  event: Machines
+  place: 3
+- team: 7
+  event: Meteorology
+  place: 8
+- team: 7
+  event: Mission Possible
+  place: 9
+- team: 7
+  event: Mousetrap Vehicle
+  place: 10
+- team: 7
+  event: Ornithology
+  place: 10
+- team: 7
+  event: Ping Pong Parachute
+  place: 1
+- team: 7
+  event: Reach for the Stars
+  place: 11
+- team: 7
+  event: Road Scholar
+  place: 4
+- team: 7
+  event: Water Quality
+  place: 4
+- team: 7
+  event: Write It Do It
+  place: 21
+- team: 8
+  event: Anatomy and Physiology
+  place: 6
+- team: 8
+  event: Boomilever
+  place: 8
+- team: 8
+  event: Circuit Lab
+  place: 2
+- team: 8
+  event: Crime Busters
+  place: 1
+- team: 8
+  event: Density Lab
+  place: 3
+- team: 8
+  event: Disease Detectives
+  place: 7
+- team: 8
+  event: Dynamic Planet
+  place: 9
+- team: 8
+  event: Elastic Launched Glider
+  place: 8
+- team: 8
+  event: Experimental Design
+  place: 3
+- team: 8
+  event: Food Science
+  place: 1
+- team: 8
+  event: Fossils
+  place: 3
+- team: 8
+  event: Game On
+  place: 2
+- team: 8
+  event: Heredity
+  place: 4
+- team: 8
+  event: Machines
+  place: 2
+- team: 8
+  event: Meteorology
+  place: 3
+- team: 8
+  event: Mission Possible
+  place: 8
+- team: 8
+  event: Mousetrap Vehicle
+  place: 5
+- team: 8
+  event: Ornithology
+  place: 3
+- team: 8
+  event: Ping Pong Parachute
+  place: 17
+- team: 8
+  event: Reach for the Stars
+  place: 5
+- team: 8
+  event: Road Scholar
+  place: 2
+- team: 8
+  event: Water Quality
+  place: 1
+- team: 8
+  event: Write It Do It
+  place: 11
+- team: 9
+  event: Anatomy and Physiology
+  place: 9
+- team: 9
+  event: Boomilever
+  place: 11
+- team: 9
+  event: Circuit Lab
+  place: 7
+- team: 9
+  event: Crime Busters
+  place: 10
+- team: 9
+  event: Density Lab
+  place: 8
+- team: 9
+  event: Disease Detectives
+  place: 9
+- team: 9
+  event: Dynamic Planet
+  place: 2
+- team: 9
+  event: Elastic Launched Glider
+  place: 21
+- team: 9
+  event: Experimental Design
+  place: 2
+- team: 9
+  event: Food Science
+  place: 4
+- team: 9
+  event: Fossils
+  place: 5
+- team: 9
+  event: Game On
+  place: 3
+- team: 9
+  event: Heredity
+  place: 10
+- team: 9
+  event: Machines
+  place: 16
+- team: 9
+  event: Meteorology
+  place: 17
+- team: 9
+  event: Mission Possible
+  place: 17
+- team: 9
+  event: Mousetrap Vehicle
+  place: 9
+- team: 9
+  event: Ornithology
+  place: 8
+- team: 9
+  event: Ping Pong Parachute
+  place: 2
+- team: 9
+  event: Reach for the Stars
+  place: 6
+- team: 9
+  event: Road Scholar
+  place: 6
+- team: 9
+  event: Water Quality
+  place: 11
+- team: 9
+  event: Write It Do It
+  place: 3
+- team: 10
+  event: Anatomy and Physiology
+  place: 13
+- team: 10
+  event: Boomilever
+  participated: false
+- team: 10
+  event: Circuit Lab
+  place: 14
+- team: 10
+  event: Crime Busters
+  place: 18
+- team: 10
+  event: Density Lab
+  participated: false
+- team: 10
+  event: Disease Detectives
+  place: 10
+- team: 10
+  event: Dynamic Planet
+  place: 17
+- team: 10
+  event: Elastic Launched Glider
+  participated: false
+- team: 10
+  event: Experimental Design
+  place: 20
+- team: 10
+  event: Food Science
+  participated: false
+- team: 10
+  event: Fossils
+  place: 28
+- team: 10
+  event: Game On
+  participated: false
+- team: 10
+  event: Heredity
+  place: 16
+- team: 10
+  event: Machines
+  participated: false
+- team: 10
+  event: Meteorology
+  place: 12
+- team: 10
+  event: Mission Possible
+  participated: false
+- team: 10
+  event: Mousetrap Vehicle
+  participated: false
+- team: 10
+  event: Ornithology
+  participated: false
+- team: 10
+  event: Ping Pong Parachute
+  participated: false
+- team: 10
+  event: Reach for the Stars
+  place: 16
+- team: 10
+  event: Road Scholar
+  participated: false
+- team: 10
+  event: Water Quality
+  participated: false
+- team: 10
+  event: Write It Do It
+  place: 10
+- team: 11
+  event: Anatomy and Physiology
+  place: 23
+- team: 11
+  event: Boomilever
+  place: 19
+- team: 11
+  event: Circuit Lab
+  place: 16
+- team: 11
+  event: Crime Busters
+  place: 11
+- team: 11
+  event: Density Lab
+  place: 22
+- team: 11
+  event: Disease Detectives
+  place: 11
+- team: 11
+  event: Dynamic Planet
+  place: 10
+- team: 11
+  event: Elastic Launched Glider
+  place: 16
+- team: 11
+  event: Experimental Design
+  place: 7
+- team: 11
+  event: Food Science
+  place: 3
+- team: 11
+  event: Fossils
+  place: 12
+- team: 11
+  event: Game On
+  place: 14
+- team: 11
+  event: Heredity
+  place: 6
+- team: 11
+  event: Machines
+  place: 11
+- team: 11
+  event: Meteorology
+  place: 14
+- team: 11
+  event: Mission Possible
+  place: 7
+- team: 11
+  event: Mousetrap Vehicle
+  place: 7
+- team: 11
+  event: Ornithology
+  place: 12
+- team: 11
+  event: Ping Pong Parachute
+  place: 11
+- team: 11
+  event: Reach for the Stars
+  place: 4
+- team: 11
+  event: Road Scholar
+  place: 17
+- team: 11
+  event: Water Quality
+  place: 12
+- team: 11
+  event: Write It Do It
+  place: 12
+- team: 12
+  event: Anatomy and Physiology
+  place: 27
+- team: 12
+  event: Boomilever
+  place: 3
+- team: 12
+  event: Circuit Lab
+  place: 25
+- team: 12
+  event: Crime Busters
+  place: 29
+- team: 12
+  event: Density Lab
+  place: 15
+- team: 12
+  event: Disease Detectives
+  place: 27
+- team: 12
+  event: Dynamic Planet
+  place: 13
+- team: 12
+  event: Elastic Launched Glider
+  place: 25
+- team: 12
+  event: Experimental Design
+  place: 19
+- team: 12
+  event: Food Science
+  place: 8
+- team: 12
+  event: Fossils
+  place: 25
+- team: 12
+  event: Game On
+  place: 20
+- team: 12
+  event: Heredity
+  place: 12
+- team: 12
+  event: Machines
+  place: 23
+- team: 12
+  event: Meteorology
+  place: 6
+- team: 12
+  event: Mission Possible
+  place: 16
+- team: 12
+  event: Mousetrap Vehicle
+  place: 1
+- team: 12
+  event: Ornithology
+  place: 27
+- team: 12
+  event: Ping Pong Parachute
+  place: 3
+- team: 12
+  event: Reach for the Stars
+  place: 17
+- team: 12
+  event: Road Scholar
+  place: 14
+- team: 12
+  event: Water Quality
+  place: 17
+- team: 12
+  event: Write It Do It
+  place: 1
+- team: 13
+  event: Anatomy and Physiology
+  place: 16
+- team: 13
+  event: Boomilever
+  place: 6
+- team: 13
+  event: Circuit Lab
+  place: 27
+- team: 13
+  event: Crime Busters
+  place: 7
+- team: 13
+  event: Density Lab
+  place: 20
+- team: 13
+  event: Disease Detectives
+  place: 19
+- team: 13
+  event: Dynamic Planet
+  place: 26
+- team: 13
+  event: Elastic Launched Glider
+  place: 11
+- team: 13
+  event: Experimental Design
+  place: 23
+- team: 13
+  event: Food Science
+  place: 12
+- team: 13
+  event: Fossils
+  place: 14
+- team: 13
+  event: Game On
+  place: 9
+- team: 13
+  event: Heredity
+  place: 21
+- team: 13
+  event: Machines
+  place: 10
+- team: 13
+  event: Meteorology
+  place: 23
+- team: 13
+  event: Mission Possible
+  place: 2
+- team: 13
+  event: Mousetrap Vehicle
+  place: 19
+- team: 13
+  event: Ornithology
+  place: 23
+- team: 13
+  event: Ping Pong Parachute
+  place: 9
+- team: 13
+  event: Reach for the Stars
+  place: 21
+- team: 13
+  event: Road Scholar
+  place: 21
+- team: 13
+  event: Water Quality
+  place: 5
+- team: 13
+  event: Write It Do It
+  place: 17
+- team: 14
+  event: Anatomy and Physiology
+  place: 26
+- team: 14
+  event: Boomilever
+  place: 17
+- team: 14
+  event: Circuit Lab
+  place: 23
+- team: 14
+  event: Crime Busters
+  place: 16
+- team: 14
+  event: Density Lab
+  place: 25
+- team: 14
+  event: Disease Detectives
+  place: 22
+- team: 14
+  event: Dynamic Planet
+  place: 15
+- team: 14
+  event: Elastic Launched Glider
+  place: 15
+- team: 14
+  event: Experimental Design
+  place: 27
+- team: 14
+  event: Food Science
+  place: 14
+- team: 14
+  event: Fossils
+  place: 22
+- team: 14
+  event: Game On
+  place: 29
+- team: 14
+  event: Heredity
+  place: 30
+- team: 14
+  event: Machines
+  place: 24
+- team: 14
+  event: Meteorology
+  place: 24
+- team: 14
+  event: Mission Possible
+  place: 10
+- team: 14
+  event: Mousetrap Vehicle
+  place: 22
+- team: 14
+  event: Ornithology
+  place: 18
+- team: 14
+  event: Ping Pong Parachute
+  place: 23
+- team: 14
+  event: Reach for the Stars
+  place: 20
+- team: 14
+  event: Road Scholar
+  place: 26
+- team: 14
+  event: Water Quality
+  place: 23
+- team: 14
+  event: Write It Do It
+  place: 22
+- team: 15
+  event: Anatomy and Physiology
+  place: 11
+- team: 15
+  event: Boomilever
+  participated: false
+- team: 15
+  event: Circuit Lab
+  place: 15
+- team: 15
+  event: Crime Busters
+  participated: false
+- team: 15
+  event: Density Lab
+  participated: false
+- team: 15
+  event: Disease Detectives
+  place: 25
+- team: 15
+  event: Dynamic Planet
+  participated: false
+- team: 15
+  event: Elastic Launched Glider
+  place: 23
+- team: 15
+  event: Experimental Design
+  place: 18
+- team: 15
+  event: Food Science
+  place: 23
+- team: 15
+  event: Fossils
+  participated: false
+- team: 15
+  event: Game On
+  place: 26
+- team: 15
+  event: Heredity
+  place: 18
+- team: 15
+  event: Machines
+  participated: false
+- team: 15
+  event: Meteorology
+  participated: false
+- team: 15
+  event: Mission Possible
+  participated: false
+- team: 15
+  event: Mousetrap Vehicle
+  place: 24
+- team: 15
+  event: Ornithology
+  participated: false
+- team: 15
+  event: Ping Pong Parachute
+  place: 14
+- team: 15
+  event: Reach for the Stars
+  place: 22
+- team: 15
+  event: Road Scholar
+  participated: false
+- team: 15
+  event: Water Quality
+  participated: false
+- team: 15
+  event: Write It Do It
+  place: 14
+- team: 16
+  event: Anatomy and Physiology
+  participated: false
+- team: 16
+  event: Boomilever
+  participated: false
+- team: 16
+  event: Circuit Lab
+  place: 12
+- team: 16
+  event: Crime Busters
+  place: 25
+- team: 16
+  event: Density Lab
+  participated: false
+- team: 16
+  event: Disease Detectives
+  participated: false
+- team: 16
+  event: Dynamic Planet
+  participated: false
+- team: 16
+  event: Elastic Launched Glider
+  participated: false
+- team: 16
+  event: Experimental Design
+  participated: false
+- team: 16
+  event: Food Science
+  participated: false
+- team: 16
+  event: Fossils
+  place: 23
+- team: 16
+  event: Game On
+  place: 21
+- team: 16
+  event: Heredity
+  place: 9
+- team: 16
+  event: Machines
+  participated: false
+- team: 16
+  event: Meteorology
+  participated: false
+- team: 16
+  event: Mission Possible
+  participated: false
+- team: 16
+  event: Mousetrap Vehicle
+  place: 28
+- team: 16
+  event: Ornithology
+  place: 13
+- team: 16
+  event: Ping Pong Parachute
+  participated: false
+- team: 16
+  event: Reach for the Stars
+  participated: false
+- team: 16
+  event: Road Scholar
+  participated: false
+- team: 16
+  event: Water Quality
+  participated: false
+- team: 16
+  event: Write It Do It
+  place: 23
+- team: 17
+  event: Anatomy and Physiology
+  place: 3
+- team: 17
+  event: Boomilever
+  place: 2
+- team: 17
+  event: Circuit Lab
+  place: 1
+- team: 17
+  event: Crime Busters
+  place: 12
+- team: 17
+  event: Density Lab
+  place: 2
+- team: 17
+  event: Disease Detectives
+  place: 8
+- team: 17
+  event: Dynamic Planet
+  place: 18
+- team: 17
+  event: Elastic Launched Glider
+  place: 1
+- team: 17
+  event: Experimental Design
+  place: 5
+- team: 17
+  event: Food Science
+  place: 15
+- team: 17
+  event: Fossils
+  place: 2
+- team: 17
+  event: Game On
+  place: 1
+- team: 17
+  event: Heredity
+  place: 2
+- team: 17
+  event: Machines
+  place: 8
+- team: 17
+  event: Meteorology
+  place: 4
+- team: 17
+  event: Mission Possible
+  place: 1
+- team: 17
+  event: Mousetrap Vehicle
+  place: 8
+- team: 17
+  event: Ornithology
+  place: 6
+- team: 17
+  event: Ping Pong Parachute
+  place: 7
+- team: 17
+  event: Reach for the Stars
+  place: 1
+- team: 17
+  event: Road Scholar
+  place: 9
+- team: 17
+  event: Water Quality
+  place: 15
+- team: 17
+  event: Write It Do It
+  place: 7
+- team: 18
+  event: Anatomy and Physiology
+  place: 12
+- team: 18
+  event: Boomilever
+  place: 1
+- team: 18
+  event: Circuit Lab
+  place: 24
+- team: 18
+  event: Crime Busters
+  place: 5
+- team: 18
+  event: Density Lab
+  place: 10
+- team: 18
+  event: Disease Detectives
+  place: 18
+- team: 18
+  event: Dynamic Planet
+  place: 22
+- team: 18
+  event: Elastic Launched Glider
+  place: 9
+- team: 18
+  event: Experimental Design
+  place: 10
+- team: 18
+  event: Food Science
+  place: 6
+- team: 18
+  event: Fossils
+  place: 4
+- team: 18
+  event: Game On
+  place: 4
+- team: 18
+  event: Heredity
+  place: 13
+- team: 18
+  event: Machines
+  place: 4
+- team: 18
+  event: Meteorology
+  place: 13
+- team: 18
+  event: Mission Possible
+  place: 20
+- team: 18
+  event: Mousetrap Vehicle
+  place: 3
+- team: 18
+  event: Ornithology
+  place: 9
+- team: 18
+  event: Ping Pong Parachute
+  place: 5
+- team: 18
+  event: Reach for the Stars
+  place: 9
+- team: 18
+  event: Road Scholar
+  place: 12
+- team: 18
+  event: Water Quality
+  place: 8
+- team: 18
+  event: Write It Do It
+  place: 13
+- team: 19
+  event: Anatomy and Physiology
+  place: 10
+- team: 19
+  event: Boomilever
+  place: 22
+- team: 19
+  event: Circuit Lab
+  place: 9
+- team: 19
+  event: Crime Busters
+  place: 9
+- team: 19
+  event: Density Lab
+  place: 11
+- team: 19
+  event: Disease Detectives
+  place: 6
+- team: 19
+  event: Dynamic Planet
+  place: 6
+- team: 19
+  event: Elastic Launched Glider
+  place: 22
+- team: 19
+  event: Experimental Design
+  place: 17
+- team: 19
+  event: Food Science
+  participated: false
+- team: 19
+  event: Fossils
+  place: 21
+- team: 19
+  event: Game On
+  participated: false
+- team: 19
+  event: Heredity
+  place: 22
+- team: 19
+  event: Machines
+  place: 7
+- team: 19
+  event: Meteorology
+  place: 1
+- team: 19
+  event: Mission Possible
+  place: 13
+- team: 19
+  event: Mousetrap Vehicle
+  place: 16
+- team: 19
+  event: Ornithology
+  place: 20
+- team: 19
+  event: Ping Pong Parachute
+  place: 20
+- team: 19
+  event: Reach for the Stars
+  place: 23
+- team: 19
+  event: Road Scholar
+  participated: false
+- team: 19
+  event: Water Quality
+  place: 10
+- team: 19
+  event: Write It Do It
+  place: 29
+- team: 20
+  event: Anatomy and Physiology
+  place: 21
+- team: 20
+  event: Boomilever
+  participated: false
+- team: 20
+  event: Circuit Lab
+  place: 29
+- team: 20
+  event: Crime Busters
+  place: 22
+- team: 20
+  event: Density Lab
+  place: 1
+- team: 20
+  event: Disease Detectives
+  place: 20
+- team: 20
+  event: Dynamic Planet
+  participated: false
+- team: 20
+  event: Elastic Launched Glider
+  place: 20
+- team: 20
+  event: Experimental Design
+  place: 22
+- team: 20
+  event: Food Science
+  place: 19
+- team: 20
+  event: Fossils
+  place: 20
+- team: 20
+  event: Game On
+  place: 22
+- team: 20
+  event: Heredity
+  place: 23
+- team: 20
+  event: Machines
+  place: 22
+- team: 20
+  event: Meteorology
+  participated: false
+- team: 20
+  event: Mission Possible
+  place: 15
+- team: 20
+  event: Mousetrap Vehicle
+  place: 17
+- team: 20
+  event: Ornithology
+  place: 21
+- team: 20
+  event: Ping Pong Parachute
+  participated: false
+- team: 20
+  event: Reach for the Stars
+  place: 12
+- team: 20
+  event: Road Scholar
+  place: 7
+- team: 20
+  event: Water Quality
+  place: 19
+- team: 20
+  event: Write It Do It
+  place: 26
+- team: 21
+  event: Anatomy and Physiology
+  place: 25
+- team: 21
+  event: Boomilever
+  place: 23
+- team: 21
+  event: Circuit Lab
+  place: 28
+- team: 21
+  event: Crime Busters
+  place: 15
+- team: 21
+  event: Density Lab
+  place: 19
+- team: 21
+  event: Disease Detectives
+  place: 21
+- team: 21
+  event: Dynamic Planet
+  place: 14
+- team: 21
+  event: Elastic Launched Glider
+  place: 26
+- team: 21
+  event: Experimental Design
+  place: 25
+- team: 21
+  event: Food Science
+  place: 13
+- team: 21
+  event: Fossils
+  place: 27
+- team: 21
+  event: Game On
+  place: 25
+- team: 21
+  event: Heredity
+  place: 27
+- team: 21
+  event: Machines
+  place: 18
+- team: 21
+  event: Meteorology
+  place: 18
+- team: 21
+  event: Mission Possible
+  place: 21
+- team: 21
+  event: Mousetrap Vehicle
+  place: 26
+- team: 21
+  event: Ornithology
+  place: 22
+- team: 21
+  event: Ping Pong Parachute
+  place: 19
+- team: 21
+  event: Reach for the Stars
+  place: 28
+- team: 21
+  event: Road Scholar
+  place: 20
+- team: 21
+  event: Water Quality
+  place: 16
+- team: 21
+  event: Write It Do It
+  place: 19
+- team: 22
+  event: Anatomy and Physiology
+  place: 24
+- team: 22
+  event: Boomilever
+  place: 21
+- team: 22
+  event: Circuit Lab
+  place: 30
+- team: 22
+  event: Crime Busters
+  place: 26
+- team: 22
+  event: Density Lab
+  place: 9
+- team: 22
+  event: Disease Detectives
+  place: 15
+- team: 22
+  event: Dynamic Planet
+  place: 16
+- team: 22
+  event: Elastic Launched Glider
+  participated: true
+- team: 22
+  event: Experimental Design
+  place: 28
+- team: 22
+  event: Food Science
+  place: 18
+- team: 22
+  event: Fossils
+  place: 18
+- team: 22
+  event: Game On
+  place: 17
+- team: 22
+  event: Heredity
+  place: 25
+- team: 22
+  event: Machines
+  place: 9
+- team: 22
+  event: Meteorology
+  place: 19
+- team: 22
+  event: Mission Possible
+  place: 19
+- team: 22
+  event: Mousetrap Vehicle
+  place: 27
+- team: 22
+  event: Ornithology
+  place: 25
+- team: 22
+  event: Ping Pong Parachute
+  place: 4
+- team: 22
+  event: Reach for the Stars
+  place: 18
+- team: 22
+  event: Road Scholar
+  place: 22
+- team: 22
+  event: Water Quality
+  place: 18
+- team: 22
+  event: Write It Do It
+  place: 18
+- team: 23
+  event: Anatomy and Physiology
+  place: 17
+- team: 23
+  event: Boomilever
+  participated: false
+- team: 23
+  event: Circuit Lab
+  participated: false
+- team: 23
+  event: Crime Busters
+  participated: false
+- team: 23
+  event: Density Lab
+  place: 26
+- team: 23
+  event: Disease Detectives
+  participated: false
+- team: 23
+  event: Dynamic Planet
+  place: 8
+- team: 23
+  event: Elastic Launched Glider
+  place: 24
+- team: 23
+  event: Experimental Design
+  place: 26
+- team: 23
+  event: Food Science
+  place: 25
+- team: 23
+  event: Fossils
+  participated: false
+- team: 23
+  event: Game On
+  place: 27
+- team: 23
+  event: Heredity
+  place: 28
+- team: 23
+  event: Machines
+  participated: false
+- team: 23
+  event: Meteorology
+  place: 27
+- team: 23
+  event: Mission Possible
+  participated: false
+- team: 23
+  event: Mousetrap Vehicle
+  participated: false
+- team: 23
+  event: Ornithology
+  place: 14
+- team: 23
+  event: Ping Pong Parachute
+  place: 22
+- team: 23
+  event: Reach for the Stars
+  participated: false
+- team: 23
+  event: Road Scholar
+  place: 23
+- team: 23
+  event: Water Quality
+  participated: false
+- team: 23
+  event: Write It Do It
+  place: 20
+- team: 24
+  event: Anatomy and Physiology
+  place: 2
+- team: 24
+  event: Boomilever
+  place: 20
+- team: 24
+  event: Circuit Lab
+  place: 10
+- team: 24
+  event: Crime Busters
+  place: 23
+- team: 24
+  event: Density Lab
+  place: 21
+- team: 24
+  event: Disease Detectives
+  place: 23
+- team: 24
+  event: Dynamic Planet
+  place: 20
+- team: 24
+  event: Elastic Launched Glider
+  place: 17
+- team: 24
+  event: Experimental Design
+  place: 16
+- team: 24
+  event: Food Science
+  place: 2
+- team: 24
+  event: Fossils
+  place: 7
+- team: 24
+  event: Game On
+  place: 19
+- team: 24
+  event: Heredity
+  place: 7
+- team: 24
+  event: Machines
+  place: 12
+- team: 24
+  event: Meteorology
+  place: 26
+- team: 24
+  event: Mission Possible
+  participated: false
+- team: 24
+  event: Mousetrap Vehicle
+  place: 23
+- team: 24
+  event: Ornithology
+  place: 24
+- team: 24
+  event: Ping Pong Parachute
+  disqualified: true
+- team: 24
+  event: Reach for the Stars
+  place: 14
+- team: 24
+  event: Road Scholar
+  place: 25
+- team: 24
+  event: Water Quality
+  place: 9
+- team: 24
+  event: Write It Do It
+  place: 16
+- team: 25
+  event: Anatomy and Physiology
+  place: 4
+- team: 25
+  event: Boomilever
+  place: 13
+- team: 25
+  event: Circuit Lab
+  place: 5
+- team: 25
+  event: Crime Busters
+  place: 4
+- team: 25
+  event: Density Lab
+  place: 4
+- team: 25
+  event: Disease Detectives
+  place: 2
+- team: 25
+  event: Dynamic Planet
+  place: 4
+- team: 25
+  event: Elastic Launched Glider
+  place: 14
+- team: 25
+  event: Experimental Design
+  place: 4
+- team: 25
+  event: Food Science
+  place: 11
+- team: 25
+  event: Fossils
+  place: 6
+- team: 25
+  event: Game On
+  place: 5
+- team: 25
+  event: Heredity
+  place: 5
+- team: 25
+  event: Machines
+  place: 5
+- team: 25
+  event: Meteorology
+  place: 20
+- team: 25
+  event: Mission Possible
+  place: 18
+- team: 25
+  event: Mousetrap Vehicle
+  place: 15
+- team: 25
+  event: Ornithology
+  place: 4
+- team: 25
+  event: Ping Pong Parachute
+  place: 24
+- team: 25
+  event: Reach for the Stars
+  place: 3
+- team: 25
+  event: Road Scholar
+  place: 15
+- team: 25
+  event: Water Quality
+  place: 2
+- team: 25
+  event: Write It Do It
+  place: 9
+- team: 26
+  event: Anatomy and Physiology
+  place: 1
+- team: 26
+  event: Boomilever
+  place: 4
+- team: 26
+  event: Circuit Lab
+  place: 3
+- team: 26
+  event: Crime Busters
+  place: 2
+- team: 26
+  event: Density Lab
+  place: 5
+- team: 26
+  event: Disease Detectives
+  place: 1
+- team: 26
+  event: Dynamic Planet
+  place: 1
+- team: 26
+  event: Elastic Launched Glider
+  place: 10
+- team: 26
+  event: Experimental Design
+  place: 1
+- team: 26
+  event: Food Science
+  place: 7
+- team: 26
+  event: Fossils
+  place: 1
+- team: 26
+  event: Game On
+  place: 8
+- team: 26
+  event: Heredity
+  place: 3
+- team: 26
+  event: Machines
+  place: 1
+- team: 26
+  event: Meteorology
+  place: 2
+- team: 26
+  event: Mission Possible
+  place: 11
+- team: 26
+  event: Mousetrap Vehicle
+  place: 11
+- team: 26
+  event: Ornithology
+  place: 2
+- team: 26
+  event: Ping Pong Parachute
+  place: 18
+- team: 26
+  event: Reach for the Stars
+  place: 2
+- team: 26
+  event: Road Scholar
+  place: 1
+- team: 26
+  event: Water Quality
+  place: 6
+- team: 26
+  event: Write It Do It
+  place: 24
+- team: 27
+  event: Anatomy and Physiology
+  participated: false
+- team: 27
+  event: Boomilever
+  participated: false
+- team: 27
+  event: Circuit Lab
+  place: 22
+- team: 27
+  event: Crime Busters
+  place: 28
+- team: 27
+  event: Density Lab
+  participated: false
+- team: 27
+  event: Disease Detectives
+  participated: false
+- team: 27
+  event: Dynamic Planet
+  place: 21
+- team: 27
+  event: Elastic Launched Glider
+  participated: false
+- team: 27
+  event: Experimental Design
+  participated: false
+- team: 27
+  event: Food Science
+  place: 28
+- team: 27
+  event: Fossils
+  participated: false
+- team: 27
+  event: Game On
+  place: 11
+- team: 27
+  event: Heredity
+  participated: false
+- team: 27
+  event: Machines
+  participated: false
+- team: 27
+  event: Meteorology
+  participated: false
+- team: 27
+  event: Mission Possible
+  participated: false
+- team: 27
+  event: Mousetrap Vehicle
+  participated: false
+- team: 27
+  event: Ornithology
+  participated: false
+- team: 27
+  event: Ping Pong Parachute
+  participated: false
+- team: 27
+  event: Reach for the Stars
+  participated: false
+- team: 27
+  event: Road Scholar
+  participated: false
+- team: 27
+  event: Water Quality
+  place: 25
+- team: 27
+  event: Write It Do It
+  participated: false
+- team: 28
+  event: Anatomy and Physiology
+  place: 20
+- team: 28
+  event: Boomilever
+  place: 16
+- team: 28
+  event: Circuit Lab
+  place: 11
+- team: 28
+  event: Crime Busters
+  place: 19
+- team: 28
+  event: Density Lab
+  place: 17
+- team: 28
+  event: Disease Detectives
+  place: 14
+- team: 28
+  event: Dynamic Planet
+  place: 19
+- team: 28
+  event: Elastic Launched Glider
+  place: 18
+- team: 28
+  event: Experimental Design
+  place: 13
+- team: 28
+  event: Food Science
+  place: 26
+- team: 28
+  event: Fossils
+  place: 24
+- team: 28
+  event: Game On
+  place: 23
+- team: 28
+  event: Heredity
+  place: 19
+- team: 28
+  event: Machines
+  place: 21
+- team: 28
+  event: Meteorology
+  place: 10
+- team: 28
+  event: Mission Possible
+  place: 22
+- team: 28
+  event: Mousetrap Vehicle
+  place: 20
+- team: 28
+  event: Ornithology
+  place: 17
+- team: 28
+  event: Ping Pong Parachute
+  place: 8
+- team: 28
+  event: Reach for the Stars
+  place: 15
+- team: 28
+  event: Road Scholar
+  place: 8
+- team: 28
+  event: Water Quality
+  place: 24
+- team: 28
+  event: Write It Do It
+  place: 25
+- team: 29
+  event: Anatomy and Physiology
+  place: 7
+- team: 29
+  event: Boomilever
+  place: 18
+- team: 29
+  event: Circuit Lab
+  place: 6
+- team: 29
+  event: Crime Busters
+  place: 13
+- team: 29
+  event: Density Lab
+  place: 6
+- team: 29
+  event: Disease Detectives
+  place: 4
+- team: 29
+  event: Dynamic Planet
+  place: 7
+- team: 29
+  event: Elastic Launched Glider
+  place: 13
+- team: 29
+  event: Experimental Design
+  place: 21
+- team: 29
+  event: Food Science
+  place: 10
+- team: 29
+  event: Fossils
+  place: 15
+- team: 29
+  event: Game On
+  place: 24
+- team: 29
+  event: Heredity
+  place: 14
+- team: 29
+  event: Machines
+  place: 6
+- team: 29
+  event: Meteorology
+  place: 5
+- team: 29
+  event: Mission Possible
+  place: 4
+- team: 29
+  event: Mousetrap Vehicle
+  place: 4
+- team: 29
+  event: Ornithology
+  place: 5
+- team: 29
+  event: Ping Pong Parachute
+  place: 12
+- team: 29
+  event: Reach for the Stars
+  place: 13
+- team: 29
+  event: Road Scholar
+  place: 5
+- team: 29
+  event: Water Quality
+  place: 14
+- team: 29
+  event: Write It Do It
+  place: 2
+- team: 30
+  event: Anatomy and Physiology
+  participated: false
+- team: 30
+  event: Boomilever
+  participated: false
+- team: 30
+  event: Circuit Lab
+  place: 20
+- team: 30
+  event: Crime Busters
+  place: 27
+- team: 30
+  event: Density Lab
+  participated: false
+- team: 30
+  event: Disease Detectives
+  place: 17
+- team: 30
+  event: Dynamic Planet
+  participated: false
+- team: 30
+  event: Elastic Launched Glider
+  participated: false
+- team: 30
+  event: Experimental Design
+  participated: false
+- team: 30
+  event: Food Science
+  place: 24
+- team: 30
+  event: Fossils
+  place: 26
+- team: 30
+  event: Game On
+  place: 7
+- team: 30
+  event: Heredity
+  place: 20
+- team: 30
+  event: Machines
+  participated: false
+- team: 30
+  event: Meteorology
+  place: 9
+- team: 30
+  event: Mission Possible
+  participated: false
+- team: 30
+  event: Mousetrap Vehicle
+  place: 18
+- team: 30
+  event: Ornithology
+  participated: false
+- team: 30
+  event: Ping Pong Parachute
+  participated: false
+- team: 30
+  event: Reach for the Stars
+  place: 27
+- team: 30
+  event: Road Scholar
+  place: 18
+- team: 30
+  event: Water Quality
+  place: 26
+- team: 30
+  event: Write It Do It
+  place: 15
+- team: 31
+  event: Anatomy and Physiology
+  place: 28
+- team: 31
+  event: Boomilever
+  participated: false
+- team: 31
+  event: Circuit Lab
+  place: 8
+- team: 31
+  event: Crime Busters
+  place: 21
+- team: 31
+  event: Density Lab
+  place: 16
+- team: 31
+  event: Disease Detectives
+  place: 28
+- team: 31
+  event: Dynamic Planet
+  place: 24
+- team: 31
+  event: Elastic Launched Glider
+  place: 12
+- team: 31
+  event: Experimental Design
+  place: 14
+- team: 31
+  event: Food Science
+  place: 27
+- team: 31
+  event: Fossils
+  place: 10
+- team: 31
+  event: Game On
+  place: 16
+- team: 31
+  event: Heredity
+  place: 26
+- team: 31
+  event: Machines
+  place: 13
+- team: 31
+  event: Meteorology
+  place: 22
+- team: 31
+  event: Mission Possible
+  participated: true
+- team: 31
+  event: Mousetrap Vehicle
+  place: 25
+- team: 31
+  event: Ornithology
+  place: 19
+- team: 31
+  event: Ping Pong Parachute
+  place: 25
+- team: 31
+  event: Reach for the Stars
+  place: 19
+- team: 31
+  event: Road Scholar
+  place: 24
+- team: 31
+  event: Water Quality
+  place: 21
+- team: 31
+  event: Write It Do It
+  place: 27

--- a/data/2020-02-29_nCA_bay_area_regional_b.yaml
+++ b/data/2020-02-29_nCA_bay_area_regional_b.yaml
@@ -1,6 +1,7 @@
 ---
 Tournament:
   name: Bay Area Regional Science Olympiad Tournament
+  short name: BARSO
   location: California State University East Bay
   state: nCA
   level: Regionals
@@ -123,7 +124,7 @@ Teams:
   school: Carmel Middle School
   state: CA
 - number: 24
-  school: Fallon Middle School
+  school: Eleanor Murray Fallon Middle School
   state: CA
 - number: 25
   school: Fred E. Weibel Elementary School

--- a/data/2020-02-29_nCA_bay_area_regional_c.yaml
+++ b/data/2020-02-29_nCA_bay_area_regional_c.yaml
@@ -1,0 +1,2873 @@
+---
+Tournament:
+  name: Bay Area Regional Science Olympiad Tournament
+  location: California State University East Bay
+  state: nCA
+  level: Regionals
+  division: C
+  year: 2020
+  date: 2020-02-29
+Events:
+- name: Anatomy and Physiology
+- name: Astronomy
+- name: Boomilever
+- name: Chemistry Lab
+- name: Circuit Lab
+- name: Codebusters
+- name: Designer Genes
+- name: Detector Building
+- name: Disease Detectives
+- name: Dynamic Planet
+- name: Experimental Design
+- name: Forensics
+- name: Fossils
+- name: Geologic Mapping
+- name: Gravity Vehicle
+- name: Machines
+- name: Ornithology
+- name: Ping Pong Parachute
+  trialed: true
+- name: Protein Modeling
+- name: Sounds of Music
+- name: Water Quality
+- name: Wright Stuff
+- name: Write It Do It
+Teams:
+- number: 1
+  school: Amador Valley High School
+  suffix: Purple
+  state: CA
+- number: 2
+  school: Amador Valley High School
+  suffix: Lavender
+  state: CA
+- number: 3
+  school: Amador Valley High School
+  suffix: Yellow
+  state: CA
+- number: 4
+  school: Amador Valley High School
+  suffix: Gold
+  state: CA
+- number: 5
+  school: Albany High School
+  suffix: White
+  state: CA
+- number: 6
+  school: Albany High School
+  suffix: Red
+  state: CA
+- number: 7
+  school: Albany High School
+  suffix: Green
+  state: CA
+- number: 8
+  school: Castro Valley High School
+  suffix: White
+  state: CA
+- number: 9
+  school: Castro Valley High School
+  suffix: Gold
+  state: CA
+- number: 10
+  school: Castro Valley High School
+  suffix: Green
+  state: CA
+- number: 11
+  school: Foothill High School
+  suffix: Blue
+  state: CA
+- number: 12
+  school: Foothill High School
+  suffix: Yellow
+  state: CA
+- number: 13
+  school: Foothill High School
+  suffix: Gold
+  state: CA
+- number: 14
+  school: Mission San Jose High School
+  suffix: Lime
+  state: CA
+- number: 15
+  school: Mission San Jose High School
+  suffix: Marigold
+  state: CA
+- number: 16
+  school: Mission San Jose High School
+  suffix: Canary
+  state: CA
+- number: 17
+  school: College Preparatory School
+  suffix: Maroon
+  state: CA
+- number: 18
+  school: College Preparatory School
+  suffix: Blue
+  state: CA
+- number: 19
+  school: College Preparatory School
+  suffix: White
+  state: CA
+- number: 20
+  school: American High School
+  suffix: Blue
+  state: CA
+- number: 21
+  school: American High School
+  suffix: Red
+  state: CA
+- number: 22
+  school: Dougherty Valley High School
+  suffix: Blue
+  state: CA
+- number: 23
+  school: Dougherty Valley High School
+  suffix: Silver
+  state: CA
+- number: 24
+  school: Dublin High School
+  suffix: Blue
+  state: CA
+- number: 25
+  school: Dublin High School
+  suffix: Red
+  state: CA
+- number: 26
+  school: Carmel High School
+  state: CA
+- number: 27
+  school: Irvington High School
+  suffix: Azure
+  state: CA
+- number: 28
+  school: Irvington High School
+  suffix: White
+  state: CA
+- number: 29
+  school: Crystal Springs Uplands School
+  state: CA
+- number: 30
+  school: Granada High School
+  state: CA
+- number: 31
+  school: Las Lomas High School
+  state: CA
+- number: 32
+  school: Livermore High School
+  state: CA
+- number: 33
+  school: Menlo-Atherton High School
+  state: CA
+- number: 34
+  school: Quarry Lane School
+  state: CA
+- number: 35
+  school: Redwood Christian High School
+  state: CA
+- number: 36
+  school: San Francisco University High School
+  state: CA
+- number: 37
+  school: Casa Grande High School
+  state: CA
+- number: 38
+  school: California High School
+  suffix: Orange
+  state: CA
+- number: 39
+  school: California High School
+  suffix: Black
+  state: CA
+Placings:
+- team: 1
+  event: Anatomy and Physiology
+  place: 5
+- team: 1
+  event: Astronomy
+  place: 14
+- team: 1
+  event: Boomilever
+  place: 24
+- team: 1
+  event: Chemistry Lab
+  place: 15
+- team: 1
+  event: Circuit Lab
+  place: 19
+- team: 1
+  event: Codebusters
+  place: 9
+- team: 1
+  event: Designer Genes
+  place: 14
+- team: 1
+  event: Detector Building
+  place: 8
+- team: 1
+  event: Disease Detectives
+  place: 26
+- team: 1
+  event: Dynamic Planet
+  place: 19
+- team: 1
+  event: Experimental Design
+  place: 23
+- team: 1
+  event: Forensics
+  place: 28
+- team: 1
+  event: Fossils
+  place: 26
+- team: 1
+  event: Geologic Mapping
+  place: 26
+- team: 1
+  event: Gravity Vehicle
+  place: 21
+- team: 1
+  event: Machines
+  place: 14
+- team: 1
+  event: Ornithology
+  place: 10
+- team: 1
+  event: Ping Pong Parachute
+  place: 19
+- team: 1
+  event: Protein Modeling
+  place: 12
+- team: 1
+  event: Sounds of Music
+  place: 16
+- team: 1
+  event: Water Quality
+  place: 6
+- team: 1
+  event: Wright Stuff
+  place: 18
+- team: 1
+  event: Write It Do It
+  place: 1
+- team: 2
+  event: Anatomy and Physiology
+  place: 11
+- team: 2
+  event: Astronomy
+  place: 10
+- team: 2
+  event: Boomilever
+  place: 29
+- team: 2
+  event: Chemistry Lab
+  place: 10
+- team: 2
+  event: Circuit Lab
+  place: 6
+- team: 2
+  event: Codebusters
+  place: 22
+- team: 2
+  event: Designer Genes
+  place: 7
+- team: 2
+  event: Detector Building
+  place: 11
+- team: 2
+  event: Disease Detectives
+  place: 13
+- team: 2
+  event: Dynamic Planet
+  place: 10
+- team: 2
+  event: Experimental Design
+  place: 20
+- team: 2
+  event: Forensics
+  place: 27
+- team: 2
+  event: Fossils
+  place: 25
+- team: 2
+  event: Geologic Mapping
+  place: 24
+- team: 2
+  event: Gravity Vehicle
+  place: 17
+- team: 2
+  event: Machines
+  place: 9
+- team: 2
+  event: Ornithology
+  place: 24
+- team: 2
+  event: Ping Pong Parachute
+  participated: false
+- team: 2
+  event: Protein Modeling
+  place: 1
+- team: 2
+  event: Sounds of Music
+  place: 7
+- team: 2
+  event: Water Quality
+  place: 18
+- team: 2
+  event: Wright Stuff
+  place: 20
+- team: 2
+  event: Write It Do It
+  place: 31
+- team: 3
+  event: Anatomy and Physiology
+  place: 6
+- team: 3
+  event: Astronomy
+  place: 26
+- team: 3
+  event: Boomilever
+  place: 14
+- team: 3
+  event: Chemistry Lab
+  place: 30
+- team: 3
+  event: Circuit Lab
+  place: 23
+- team: 3
+  event: Codebusters
+  place: 20
+- team: 3
+  event: Designer Genes
+  place: 16
+- team: 3
+  event: Detector Building
+  place: 5
+- team: 3
+  event: Disease Detectives
+  place: 30
+- team: 3
+  event: Dynamic Planet
+  place: 22
+- team: 3
+  event: Experimental Design
+  place: 17
+- team: 3
+  event: Forensics
+  place: 29
+- team: 3
+  event: Fossils
+  place: 16
+- team: 3
+  event: Geologic Mapping
+  place: 15
+- team: 3
+  event: Gravity Vehicle
+  place: 13
+- team: 3
+  event: Machines
+  place: 18
+- team: 3
+  event: Ornithology
+  place: 31
+- team: 3
+  event: Ping Pong Parachute
+  place: 17
+- team: 3
+  event: Protein Modeling
+  place: 11
+- team: 3
+  event: Sounds of Music
+  place: 12
+- team: 3
+  event: Water Quality
+  place: 11
+- team: 3
+  event: Wright Stuff
+  place: 24
+- team: 3
+  event: Write It Do It
+  place: 20
+- team: 4
+  event: Anatomy and Physiology
+  place: 33
+- team: 4
+  event: Astronomy
+  place: 23
+- team: 4
+  event: Boomilever
+  place: 26
+- team: 4
+  event: Chemistry Lab
+  place: 24
+- team: 4
+  event: Circuit Lab
+  place: 34
+- team: 4
+  event: Codebusters
+  place: 18
+- team: 4
+  event: Designer Genes
+  place: 18
+- team: 4
+  event: Detector Building
+  place: 23
+- team: 4
+  event: Disease Detectives
+  place: 22
+- team: 4
+  event: Dynamic Planet
+  place: 25
+- team: 4
+  event: Experimental Design
+  place: 15
+- team: 4
+  event: Forensics
+  place: 20
+- team: 4
+  event: Fossils
+  place: 20
+- team: 4
+  event: Geologic Mapping
+  place: 18
+- team: 4
+  event: Gravity Vehicle
+  participated: true
+- team: 4
+  event: Machines
+  place: 8
+- team: 4
+  event: Ornithology
+  place: 23
+- team: 4
+  event: Ping Pong Parachute
+  place: 11
+- team: 4
+  event: Protein Modeling
+  place: 15
+- team: 4
+  event: Sounds of Music
+  place: 26
+- team: 4
+  event: Water Quality
+  place: 23
+- team: 4
+  event: Wright Stuff
+  place: 15
+- team: 4
+  event: Write It Do It
+  place: 19
+- team: 5
+  event: Anatomy and Physiology
+  place: 14
+- team: 5
+  event: Astronomy
+  place: 4
+- team: 5
+  event: Boomilever
+  place: 1
+- team: 5
+  event: Chemistry Lab
+  place: 5
+- team: 5
+  event: Circuit Lab
+  place: 20
+- team: 5
+  event: Codebusters
+  place: 2
+- team: 5
+  event: Designer Genes
+  place: 3
+- team: 5
+  event: Detector Building
+  place: 9
+- team: 5
+  event: Disease Detectives
+  place: 2
+- team: 5
+  event: Dynamic Planet
+  place: 14
+- team: 5
+  event: Experimental Design
+  place: 3
+- team: 5
+  event: Forensics
+  place: 6
+- team: 5
+  event: Fossils
+  place: 2
+- team: 5
+  event: Geologic Mapping
+  place: 6
+- team: 5
+  event: Gravity Vehicle
+  place: 1
+- team: 5
+  event: Machines
+  place: 17
+- team: 5
+  event: Ornithology
+  place: 2
+- team: 5
+  event: Ping Pong Parachute
+  place: 3
+- team: 5
+  event: Protein Modeling
+  place: 5
+- team: 5
+  event: Sounds of Music
+  place: 10
+- team: 5
+  event: Water Quality
+  place: 7
+- team: 5
+  event: Wright Stuff
+  place: 3
+- team: 5
+  event: Write It Do It
+  place: 9
+- team: 6
+  event: Anatomy and Physiology
+  place: 34
+- team: 6
+  event: Astronomy
+  participated: false
+- team: 6
+  event: Boomilever
+  participated: false
+- team: 6
+  event: Chemistry Lab
+  place: 22
+- team: 6
+  event: Circuit Lab
+  place: 13
+- team: 6
+  event: Codebusters
+  place: 31
+- team: 6
+  event: Designer Genes
+  participated: false
+- team: 6
+  event: Detector Building
+  place: 6
+- team: 6
+  event: Disease Detectives
+  place: 11
+- team: 6
+  event: Dynamic Planet
+  place: 4
+- team: 6
+  event: Experimental Design
+  place: 10
+- team: 6
+  event: Forensics
+  place: 15
+- team: 6
+  event: Fossils
+  place: 17
+- team: 6
+  event: Geologic Mapping
+  place: 7
+- team: 6
+  event: Gravity Vehicle
+  participated: false
+- team: 6
+  event: Machines
+  participated: false
+- team: 6
+  event: Ornithology
+  place: 6
+- team: 6
+  event: Ping Pong Parachute
+  place: 14
+- team: 6
+  event: Protein Modeling
+  participated: false
+- team: 6
+  event: Sounds of Music
+  place: 9
+- team: 6
+  event: Water Quality
+  participated: false
+- team: 6
+  event: Wright Stuff
+  place: 17
+- team: 6
+  event: Write It Do It
+  place: 23
+- team: 7
+  event: Anatomy and Physiology
+  place: 29
+- team: 7
+  event: Astronomy
+  participated: false
+- team: 7
+  event: Boomilever
+  place: 12
+- team: 7
+  event: Chemistry Lab
+  place: 27
+- team: 7
+  event: Circuit Lab
+  place: 24
+- team: 7
+  event: Codebusters
+  participated: false
+- team: 7
+  event: Designer Genes
+  participated: false
+- team: 7
+  event: Detector Building
+  participated: false
+- team: 7
+  event: Disease Detectives
+  participated: false
+- team: 7
+  event: Dynamic Planet
+  place: 28
+- team: 7
+  event: Experimental Design
+  participated: false
+- team: 7
+  event: Forensics
+  place: 8
+- team: 7
+  event: Fossils
+  place: 13
+- team: 7
+  event: Geologic Mapping
+  place: 9
+- team: 7
+  event: Gravity Vehicle
+  participated: false
+- team: 7
+  event: Machines
+  participated: false
+- team: 7
+  event: Ornithology
+  participated: false
+- team: 7
+  event: Ping Pong Parachute
+  place: 8
+- team: 7
+  event: Protein Modeling
+  place: 13
+- team: 7
+  event: Sounds of Music
+  place: 27
+- team: 7
+  event: Water Quality
+  participated: false
+- team: 7
+  event: Wright Stuff
+  place: 11
+- team: 7
+  event: Write It Do It
+  participated: false
+- team: 8
+  event: Anatomy and Physiology
+  place: 7
+- team: 8
+  event: Astronomy
+  place: 8
+- team: 8
+  event: Boomilever
+  place: 3
+- team: 8
+  event: Chemistry Lab
+  place: 13
+- team: 8
+  event: Circuit Lab
+  place: 8
+- team: 8
+  event: Codebusters
+  place: 10
+- team: 8
+  event: Designer Genes
+  place: 28
+- team: 8
+  event: Detector Building
+  place: 4
+- team: 8
+  event: Disease Detectives
+  place: 12
+- team: 8
+  event: Dynamic Planet
+  place: 21
+- team: 8
+  event: Experimental Design
+  place: 11
+- team: 8
+  event: Forensics
+  place: 7
+- team: 8
+  event: Fossils
+  place: 4
+- team: 8
+  event: Geologic Mapping
+  place: 11
+- team: 8
+  event: Gravity Vehicle
+  place: 4
+- team: 8
+  event: Machines
+  place: 11
+- team: 8
+  event: Ornithology
+  place: 9
+- team: 8
+  event: Ping Pong Parachute
+  place: 5
+- team: 8
+  event: Protein Modeling
+  place: 14
+- team: 8
+  event: Sounds of Music
+  place: 4
+- team: 8
+  event: Water Quality
+  place: 13
+- team: 8
+  event: Wright Stuff
+  place: 5
+- team: 8
+  event: Write It Do It
+  place: 3
+- team: 9
+  event: Anatomy and Physiology
+  place: 12
+- team: 9
+  event: Astronomy
+  place: 22
+- team: 9
+  event: Boomilever
+  place: 2
+- team: 9
+  event: Chemistry Lab
+  place: 4
+- team: 9
+  event: Circuit Lab
+  place: 9
+- team: 9
+  event: Codebusters
+  place: 14
+- team: 9
+  event: Designer Genes
+  place: 29
+- team: 9
+  event: Detector Building
+  place: 2
+- team: 9
+  event: Disease Detectives
+  place: 28
+- team: 9
+  event: Dynamic Planet
+  place: 18
+- team: 9
+  event: Experimental Design
+  place: 14
+- team: 9
+  event: Forensics
+  place: 21
+- team: 9
+  event: Fossils
+  place: 10
+- team: 9
+  event: Geologic Mapping
+  place: 21
+- team: 9
+  event: Gravity Vehicle
+  place: 5
+- team: 9
+  event: Machines
+  place: 3
+- team: 9
+  event: Ornithology
+  place: 17
+- team: 9
+  event: Ping Pong Parachute
+  place: 4
+- team: 9
+  event: Protein Modeling
+  place: 20
+- team: 9
+  event: Sounds of Music
+  place: 25
+- team: 9
+  event: Water Quality
+  place: 17
+- team: 9
+  event: Wright Stuff
+  place: 9
+- team: 9
+  event: Write It Do It
+  place: 25
+- team: 10
+  event: Anatomy and Physiology
+  place: 31
+- team: 10
+  event: Astronomy
+  place: 19
+- team: 10
+  event: Boomilever
+  place: 5
+- team: 10
+  event: Chemistry Lab
+  place: 26
+- team: 10
+  event: Circuit Lab
+  place: 21
+- team: 10
+  event: Codebusters
+  participated: false
+- team: 10
+  event: Designer Genes
+  place: 30
+- team: 10
+  event: Detector Building
+  participated: false
+- team: 10
+  event: Disease Detectives
+  place: 16
+- team: 10
+  event: Dynamic Planet
+  place: 27
+- team: 10
+  event: Experimental Design
+  place: 22
+- team: 10
+  event: Forensics
+  place: 12
+- team: 10
+  event: Fossils
+  place: 1
+- team: 10
+  event: Geologic Mapping
+  place: 19
+- team: 10
+  event: Gravity Vehicle
+  place: 15
+- team: 10
+  event: Machines
+  place: 13
+- team: 10
+  event: Ornithology
+  place: 14
+- team: 10
+  event: Ping Pong Parachute
+  place: 18
+- team: 10
+  event: Protein Modeling
+  participated: false
+- team: 10
+  event: Sounds of Music
+  place: 28
+- team: 10
+  event: Water Quality
+  place: 21
+- team: 10
+  event: Wright Stuff
+  place: 8
+- team: 10
+  event: Write It Do It
+  place: 17
+- team: 11
+  event: Anatomy and Physiology
+  place: 4
+- team: 11
+  event: Astronomy
+  place: 12
+- team: 11
+  event: Boomilever
+  place: 28
+- team: 11
+  event: Chemistry Lab
+  place: 28
+- team: 11
+  event: Circuit Lab
+  place: 18
+- team: 11
+  event: Codebusters
+  place: 4
+- team: 11
+  event: Designer Genes
+  place: 2
+- team: 11
+  event: Detector Building
+  place: 16
+- team: 11
+  event: Disease Detectives
+  place: 20
+- team: 11
+  event: Dynamic Planet
+  place: 24
+- team: 11
+  event: Experimental Design
+  place: 6
+- team: 11
+  event: Forensics
+  place: 19
+- team: 11
+  event: Fossils
+  place: 11
+- team: 11
+  event: Geologic Mapping
+  place: 16
+- team: 11
+  event: Gravity Vehicle
+  place: 8
+- team: 11
+  event: Machines
+  place: 6
+- team: 11
+  event: Ornithology
+  place: 12
+- team: 11
+  event: Ping Pong Parachute
+  place: 28
+- team: 11
+  event: Protein Modeling
+  place: 3
+- team: 11
+  event: Sounds of Music
+  place: 5
+- team: 11
+  event: Water Quality
+  place: 10
+- team: 11
+  event: Wright Stuff
+  place: 16
+- team: 11
+  event: Write It Do It
+  place: 10
+- team: 12
+  event: Anatomy and Physiology
+  place: 15
+- team: 12
+  event: Astronomy
+  place: 15
+- team: 12
+  event: Boomilever
+  place: 22
+- team: 12
+  event: Chemistry Lab
+  place: 31
+- team: 12
+  event: Circuit Lab
+  place: 28
+- team: 12
+  event: Codebusters
+  place: 28
+- team: 12
+  event: Designer Genes
+  place: 20
+- team: 12
+  event: Detector Building
+  place: 21
+- team: 12
+  event: Disease Detectives
+  place: 5
+- team: 12
+  event: Dynamic Planet
+  place: 26
+- team: 12
+  event: Experimental Design
+  place: 7
+- team: 12
+  event: Forensics
+  place: 30
+- team: 12
+  event: Fossils
+  place: 14
+- team: 12
+  event: Geologic Mapping
+  place: 17
+- team: 12
+  event: Gravity Vehicle
+  place: 16
+- team: 12
+  event: Machines
+  place: 19
+- team: 12
+  event: Ornithology
+  place: 25
+- team: 12
+  event: Ping Pong Parachute
+  place: 9
+- team: 12
+  event: Protein Modeling
+  place: 16
+- team: 12
+  event: Sounds of Music
+  place: 29
+- team: 12
+  event: Water Quality
+  place: 19
+- team: 12
+  event: Wright Stuff
+  place: 23
+- team: 12
+  event: Write It Do It
+  place: 24
+- team: 13
+  event: Anatomy and Physiology
+  place: 32
+- team: 13
+  event: Astronomy
+  place: 16
+- team: 13
+  event: Boomilever
+  place: 11
+- team: 13
+  event: Chemistry Lab
+  place: 11
+- team: 13
+  event: Circuit Lab
+  place: 26
+- team: 13
+  event: Codebusters
+  place: 33
+- team: 13
+  event: Designer Genes
+  place: 27
+- team: 13
+  event: Detector Building
+  participated: false
+- team: 13
+  event: Disease Detectives
+  place: 21
+- team: 13
+  event: Dynamic Planet
+  participated: false
+- team: 13
+  event: Experimental Design
+  place: 19
+- team: 13
+  event: Forensics
+  place: 14
+- team: 13
+  event: Fossils
+  place: 19
+- team: 13
+  event: Geologic Mapping
+  place: 13
+- team: 13
+  event: Gravity Vehicle
+  place: 6
+- team: 13
+  event: Machines
+  participated: false
+- team: 13
+  event: Ornithology
+  place: 26
+- team: 13
+  event: Ping Pong Parachute
+  participated: false
+- team: 13
+  event: Protein Modeling
+  place: 25
+- team: 13
+  event: Sounds of Music
+  participated: false
+- team: 13
+  event: Water Quality
+  place: 30
+- team: 13
+  event: Wright Stuff
+  participated: false
+- team: 13
+  event: Write It Do It
+  place: 32
+- team: 14
+  event: Anatomy and Physiology
+  place: 1
+- team: 14
+  event: Astronomy
+  place: 2
+- team: 14
+  event: Boomilever
+  place: 6
+- team: 14
+  event: Chemistry Lab
+  place: 2
+- team: 14
+  event: Circuit Lab
+  place: 4
+- team: 14
+  event: Codebusters
+  place: 1
+- team: 14
+  event: Designer Genes
+  place: 1
+- team: 14
+  event: Detector Building
+  place: 15
+- team: 14
+  event: Disease Detectives
+  place: 3
+- team: 14
+  event: Dynamic Planet
+  place: 1
+- team: 14
+  event: Experimental Design
+  place: 2
+- team: 14
+  event: Forensics
+  place: 1
+- team: 14
+  event: Fossils
+  place: 9
+- team: 14
+  event: Geologic Mapping
+  place: 1
+- team: 14
+  event: Gravity Vehicle
+  place: 3
+- team: 14
+  event: Machines
+  place: 4
+- team: 14
+  event: Ornithology
+  place: 3
+- team: 14
+  event: Ping Pong Parachute
+  place: 10
+- team: 14
+  event: Protein Modeling
+  place: 2
+- team: 14
+  event: Sounds of Music
+  place: 8
+- team: 14
+  event: Water Quality
+  place: 3
+- team: 14
+  event: Wright Stuff
+  place: 10
+- team: 14
+  event: Write It Do It
+  place: 4
+- team: 15
+  event: Anatomy and Physiology
+  place: 20
+- team: 15
+  event: Astronomy
+  place: 17
+- team: 15
+  event: Boomilever
+  place: 13
+- team: 15
+  event: Chemistry Lab
+  place: 8
+- team: 15
+  event: Circuit Lab
+  place: 16
+- team: 15
+  event: Codebusters
+  place: 15
+- team: 15
+  event: Designer Genes
+  place: 12
+- team: 15
+  event: Detector Building
+  place: 20
+- team: 15
+  event: Disease Detectives
+  place: 9
+- team: 15
+  event: Dynamic Planet
+  place: 13
+- team: 15
+  event: Experimental Design
+  place: 5
+- team: 15
+  event: Forensics
+  place: 2
+- team: 15
+  event: Fossils
+  place: 15
+- team: 15
+  event: Geologic Mapping
+  place: 8
+- team: 15
+  event: Gravity Vehicle
+  place: 7
+- team: 15
+  event: Machines
+  place: 12
+- team: 15
+  event: Ornithology
+  place: 15
+- team: 15
+  event: Ping Pong Parachute
+  place: 27
+- team: 15
+  event: Protein Modeling
+  place: 6
+- team: 15
+  event: Sounds of Music
+  place: 13
+- team: 15
+  event: Water Quality
+  place: 9
+- team: 15
+  event: Wright Stuff
+  place: 6
+- team: 15
+  event: Write It Do It
+  place: 2
+- team: 16
+  event: Anatomy and Physiology
+  place: 24
+- team: 16
+  event: Astronomy
+  participated: false
+- team: 16
+  event: Boomilever
+  place: 18
+- team: 16
+  event: Chemistry Lab
+  place: 29
+- team: 16
+  event: Circuit Lab
+  place: 12
+- team: 16
+  event: Codebusters
+  place: 12
+- team: 16
+  event: Designer Genes
+  place: 25
+- team: 16
+  event: Detector Building
+  participated: false
+- team: 16
+  event: Disease Detectives
+  place: 19
+- team: 16
+  event: Dynamic Planet
+  place: 8
+- team: 16
+  event: Experimental Design
+  place: 16
+- team: 16
+  event: Forensics
+  place: 31
+- team: 16
+  event: Fossils
+  place: 30
+- team: 16
+  event: Geologic Mapping
+  participated: false
+- team: 16
+  event: Gravity Vehicle
+  place: 20
+- team: 16
+  event: Machines
+  participated: false
+- team: 16
+  event: Ornithology
+  participated: false
+- team: 16
+  event: Ping Pong Parachute
+  place: 23
+- team: 16
+  event: Protein Modeling
+  participated: false
+- team: 16
+  event: Sounds of Music
+  place: 14
+- team: 16
+  event: Water Quality
+  place: 33
+- team: 16
+  event: Wright Stuff
+  participated: false
+- team: 16
+  event: Write It Do It
+  participated: false
+- team: 17
+  event: Anatomy and Physiology
+  place: 26
+- team: 17
+  event: Astronomy
+  place: 5
+- team: 17
+  event: Boomilever
+  participated: false
+- team: 17
+  event: Chemistry Lab
+  place: 17
+- team: 17
+  event: Circuit Lab
+  place: 1
+- team: 17
+  event: Codebusters
+  place: 8
+- team: 17
+  event: Designer Genes
+  place: 15
+- team: 17
+  event: Detector Building
+  place: 19
+- team: 17
+  event: Disease Detectives
+  place: 23
+- team: 17
+  event: Dynamic Planet
+  place: 5
+- team: 17
+  event: Experimental Design
+  place: 30
+- team: 17
+  event: Forensics
+  place: 23
+- team: 17
+  event: Fossils
+  place: 18
+- team: 17
+  event: Geologic Mapping
+  place: 12
+- team: 17
+  event: Gravity Vehicle
+  participated: false
+- team: 17
+  event: Machines
+  place: 21
+- team: 17
+  event: Ornithology
+  place: 16
+- team: 17
+  event: Ping Pong Parachute
+  participated: false
+- team: 17
+  event: Protein Modeling
+  place: 21
+- team: 17
+  event: Sounds of Music
+  participated: false
+- team: 17
+  event: Water Quality
+  place: 15
+- team: 17
+  event: Wright Stuff
+  place: 22
+- team: 17
+  event: Write It Do It
+  place: 22
+- team: 18
+  event: Anatomy and Physiology
+  place: 36
+- team: 18
+  event: Astronomy
+  place: 25
+- team: 18
+  event: Boomilever
+  participated: false
+- team: 18
+  event: Chemistry Lab
+  place: 32
+- team: 18
+  event: Circuit Lab
+  participated: false
+- team: 18
+  event: Codebusters
+  place: 27
+- team: 18
+  event: Designer Genes
+  place: 10
+- team: 18
+  event: Detector Building
+  participated: false
+- team: 18
+  event: Disease Detectives
+  participated: false
+- team: 18
+  event: Dynamic Planet
+  place: 15
+- team: 18
+  event: Experimental Design
+  place: 28
+- team: 18
+  event: Forensics
+  place: 26
+- team: 18
+  event: Fossils
+  place: 23
+- team: 18
+  event: Geologic Mapping
+  place: 14
+- team: 18
+  event: Gravity Vehicle
+  place: 19
+- team: 18
+  event: Machines
+  place: 24
+- team: 18
+  event: Ornithology
+  place: 21
+- team: 18
+  event: Ping Pong Parachute
+  place: 12
+- team: 18
+  event: Protein Modeling
+  participated: false
+- team: 18
+  event: Sounds of Music
+  participated: false
+- team: 18
+  event: Water Quality
+  place: 32
+- team: 18
+  event: Wright Stuff
+  place: 25
+- team: 18
+  event: Write It Do It
+  place: 33
+- team: 19
+  event: Anatomy and Physiology
+  place: 35
+- team: 19
+  event: Astronomy
+  place: 18
+- team: 19
+  event: Boomilever
+  participated: false
+- team: 19
+  event: Chemistry Lab
+  participated: false
+- team: 19
+  event: Circuit Lab
+  place: 29
+- team: 19
+  event: Codebusters
+  place: 24
+- team: 19
+  event: Designer Genes
+  place: 26
+- team: 19
+  event: Detector Building
+  participated: false
+- team: 19
+  event: Disease Detectives
+  place: 10
+- team: 19
+  event: Dynamic Planet
+  place: 29
+- team: 19
+  event: Experimental Design
+  participated: false
+- team: 19
+  event: Forensics
+  place: 32
+- team: 19
+  event: Fossils
+  participated: false
+- team: 19
+  event: Geologic Mapping
+  place: 10
+- team: 19
+  event: Gravity Vehicle
+  participated: false
+- team: 19
+  event: Machines
+  participated: false
+- team: 19
+  event: Ornithology
+  place: 20
+- team: 19
+  event: Ping Pong Parachute
+  place: 16
+- team: 19
+  event: Protein Modeling
+  participated: false
+- team: 19
+  event: Sounds of Music
+  place: 20
+- team: 19
+  event: Water Quality
+  place: 27
+- team: 19
+  event: Wright Stuff
+  participated: false
+- team: 19
+  event: Write It Do It
+  place: 6
+- team: 20
+  event: Anatomy and Physiology
+  place: 10
+- team: 20
+  event: Astronomy
+  place: 7
+- team: 20
+  event: Boomilever
+  place: 10
+- team: 20
+  event: Chemistry Lab
+  place: 9
+- team: 20
+  event: Circuit Lab
+  place: 5
+- team: 20
+  event: Codebusters
+  place: 6
+- team: 20
+  event: Designer Genes
+  place: 4
+- team: 20
+  event: Detector Building
+  place: 1
+- team: 20
+  event: Disease Detectives
+  place: 1
+- team: 20
+  event: Dynamic Planet
+  place: 3
+- team: 20
+  event: Experimental Design
+  place: 1
+- team: 20
+  event: Forensics
+  place: 4
+- team: 20
+  event: Fossils
+  place: 3
+- team: 20
+  event: Geologic Mapping
+  place: 3
+- team: 20
+  event: Gravity Vehicle
+  place: 2
+- team: 20
+  event: Machines
+  place: 2
+- team: 20
+  event: Ornithology
+  place: 1
+- team: 20
+  event: Ping Pong Parachute
+  place: 2
+- team: 20
+  event: Protein Modeling
+  place: 4
+- team: 20
+  event: Sounds of Music
+  place: 1
+- team: 20
+  event: Water Quality
+  place: 1
+- team: 20
+  event: Wright Stuff
+  place: 4
+- team: 20
+  event: Write It Do It
+  place: 8
+- team: 21
+  event: Anatomy and Physiology
+  place: 19
+- team: 21
+  event: Astronomy
+  place: 9
+- team: 21
+  event: Boomilever
+  place: 4
+- team: 21
+  event: Chemistry Lab
+  place: 12
+- team: 21
+  event: Circuit Lab
+  place: 7
+- team: 21
+  event: Codebusters
+  place: 11
+- team: 21
+  event: Designer Genes
+  place: 8
+- team: 21
+  event: Detector Building
+  place: 3
+- team: 21
+  event: Disease Detectives
+  place: 4
+- team: 21
+  event: Dynamic Planet
+  place: 9
+- team: 21
+  event: Experimental Design
+  place: 4
+- team: 21
+  event: Forensics
+  place: 5
+- team: 21
+  event: Fossils
+  place: 7
+- team: 21
+  event: Geologic Mapping
+  place: 20
+- team: 21
+  event: Gravity Vehicle
+  place: 10
+- team: 21
+  event: Machines
+  place: 7
+- team: 21
+  event: Ornithology
+  place: 7
+- team: 21
+  event: Ping Pong Parachute
+  place: 1
+- team: 21
+  event: Protein Modeling
+  place: 9
+- team: 21
+  event: Sounds of Music
+  place: 3
+- team: 21
+  event: Water Quality
+  place: 4
+- team: 21
+  event: Wright Stuff
+  place: 2
+- team: 21
+  event: Write It Do It
+  place: 14
+- team: 22
+  event: Anatomy and Physiology
+  place: 18
+- team: 22
+  event: Astronomy
+  participated: false
+- team: 22
+  event: Boomilever
+  place: 25
+- team: 22
+  event: Chemistry Lab
+  participated: false
+- team: 22
+  event: Circuit Lab
+  participated: false
+- team: 22
+  event: Codebusters
+  place: 25
+- team: 22
+  event: Designer Genes
+  place: 13
+- team: 22
+  event: Detector Building
+  place: 22
+- team: 22
+  event: Disease Detectives
+  place: 27
+- team: 22
+  event: Dynamic Planet
+  place: 11
+- team: 22
+  event: Experimental Design
+  place: 21
+- team: 22
+  event: Forensics
+  place: 22
+- team: 22
+  event: Fossils
+  participated: false
+- team: 22
+  event: Geologic Mapping
+  place: 28
+- team: 22
+  event: Gravity Vehicle
+  participated: false
+- team: 22
+  event: Machines
+  participated: false
+- team: 22
+  event: Ornithology
+  place: 19
+- team: 22
+  event: Ping Pong Parachute
+  participated: false
+- team: 22
+  event: Protein Modeling
+  place: 22
+- team: 22
+  event: Sounds of Music
+  participated: false
+- team: 22
+  event: Water Quality
+  place: 31
+- team: 22
+  event: Wright Stuff
+  place: 21
+- team: 22
+  event: Write It Do It
+  place: 29
+- team: 23
+  event: Anatomy and Physiology
+  place: 28
+- team: 23
+  event: Astronomy
+  place: 20
+- team: 23
+  event: Boomilever
+  participated: false
+- team: 23
+  event: Chemistry Lab
+  place: 18
+- team: 23
+  event: Circuit Lab
+  place: 25
+- team: 23
+  event: Codebusters
+  place: 30
+- team: 23
+  event: Designer Genes
+  place: 17
+- team: 23
+  event: Detector Building
+  participated: false
+- team: 23
+  event: Disease Detectives
+  place: 29
+- team: 23
+  event: Dynamic Planet
+  place: 6
+- team: 23
+  event: Experimental Design
+  place: 12
+- team: 23
+  event: Forensics
+  place: 18
+- team: 23
+  event: Fossils
+  place: 22
+- team: 23
+  event: Geologic Mapping
+  place: 4
+- team: 23
+  event: Gravity Vehicle
+  place: 24
+- team: 23
+  event: Machines
+  place: 25
+- team: 23
+  event: Ornithology
+  place: 29
+- team: 23
+  event: Ping Pong Parachute
+  participated: false
+- team: 23
+  event: Protein Modeling
+  place: 24
+- team: 23
+  event: Sounds of Music
+  place: 21
+- team: 23
+  event: Water Quality
+  place: 24
+- team: 23
+  event: Wright Stuff
+  place: 19
+- team: 23
+  event: Write It Do It
+  place: 21
+- team: 24
+  event: Anatomy and Physiology
+  place: 17
+- team: 24
+  event: Astronomy
+  place: 21
+- team: 24
+  event: Boomilever
+  place: 8
+- team: 24
+  event: Chemistry Lab
+  place: 19
+- team: 24
+  event: Circuit Lab
+  place: 22
+- team: 24
+  event: Codebusters
+  place: 13
+- team: 24
+  event: Designer Genes
+  place: 22
+- team: 24
+  event: Detector Building
+  place: 13
+- team: 24
+  event: Disease Detectives
+  place: 14
+- team: 24
+  event: Dynamic Planet
+  place: 23
+- team: 24
+  event: Experimental Design
+  place: 24
+- team: 24
+  event: Forensics
+  place: 25
+- team: 24
+  event: Fossils
+  participated: false
+- team: 24
+  event: Geologic Mapping
+  place: 27
+- team: 24
+  event: Gravity Vehicle
+  participated: false
+- team: 24
+  event: Machines
+  place: 20
+- team: 24
+  event: Ornithology
+  participated: false
+- team: 24
+  event: Ping Pong Parachute
+  participated: false
+- team: 24
+  event: Protein Modeling
+  place: 23
+- team: 24
+  event: Sounds of Music
+  place: 11
+- team: 24
+  event: Water Quality
+  place: 29
+- team: 24
+  event: Wright Stuff
+  participated: false
+- team: 24
+  event: Write It Do It
+  place: 13
+- team: 25
+  event: Anatomy and Physiology
+  place: 2
+- team: 25
+  event: Astronomy
+  place: 6
+- team: 25
+  event: Boomilever
+  place: 7
+- team: 25
+  event: Chemistry Lab
+  place: 3
+- team: 25
+  event: Circuit Lab
+  place: 15
+- team: 25
+  event: Codebusters
+  place: 3
+- team: 25
+  event: Designer Genes
+  place: 6
+- team: 25
+  event: Detector Building
+  place: 10
+- team: 25
+  event: Disease Detectives
+  place: 8
+- team: 25
+  event: Dynamic Planet
+  place: 7
+- team: 25
+  event: Experimental Design
+  place: 8
+- team: 25
+  event: Forensics
+  place: 3
+- team: 25
+  event: Fossils
+  place: 6
+- team: 25
+  event: Geologic Mapping
+  place: 5
+- team: 25
+  event: Gravity Vehicle
+  place: 9
+- team: 25
+  event: Machines
+  place: 5
+- team: 25
+  event: Ornithology
+  place: 5
+- team: 25
+  event: Ping Pong Parachute
+  place: 6
+- team: 25
+  event: Protein Modeling
+  place: 10
+- team: 25
+  event: Sounds of Music
+  place: 2
+- team: 25
+  event: Water Quality
+  place: 2
+- team: 25
+  event: Wright Stuff
+  place: 7
+- team: 25
+  event: Write It Do It
+  place: 12
+- team: 26
+  event: Anatomy and Physiology
+  place: 22
+- team: 26
+  event: Astronomy
+  place: 13
+- team: 26
+  event: Boomilever
+  participated: false
+- team: 26
+  event: Chemistry Lab
+  place: 33
+- team: 26
+  event: Circuit Lab
+  place: 31
+- team: 26
+  event: Codebusters
+  place: 21
+- team: 26
+  event: Designer Genes
+  place: 19
+- team: 26
+  event: Detector Building
+  participated: false
+- team: 26
+  event: Disease Detectives
+  place: 32
+- team: 26
+  event: Dynamic Planet
+  place: 20
+- team: 26
+  event: Experimental Design
+  place: 29
+- team: 26
+  event: Forensics
+  place: 24
+- team: 26
+  event: Fossils
+  place: 28
+- team: 26
+  event: Geologic Mapping
+  participated: false
+- team: 26
+  event: Gravity Vehicle
+  participated: false
+- team: 26
+  event: Machines
+  participated: false
+- team: 26
+  event: Ornithology
+  place: 18
+- team: 26
+  event: Ping Pong Parachute
+  participated: false
+- team: 26
+  event: Protein Modeling
+  participated: false
+- team: 26
+  event: Sounds of Music
+  place: 23
+- team: 26
+  event: Water Quality
+  place: 22
+- team: 26
+  event: Wright Stuff
+  place: 12
+- team: 26
+  event: Write It Do It
+  place: 15
+- team: 27
+  event: Anatomy and Physiology
+  place: 3
+- team: 27
+  event: Astronomy
+  place: 1
+- team: 27
+  event: Boomilever
+  place: 9
+- team: 27
+  event: Chemistry Lab
+  place: 6
+- team: 27
+  event: Circuit Lab
+  place: 14
+- team: 27
+  event: Codebusters
+  place: 5
+- team: 27
+  event: Designer Genes
+  place: 9
+- team: 27
+  event: Detector Building
+  place: 7
+- team: 27
+  event: Disease Detectives
+  place: 6
+- team: 27
+  event: Dynamic Planet
+  place: 2
+- team: 27
+  event: Experimental Design
+  place: 9
+- team: 27
+  event: Forensics
+  place: 11
+- team: 27
+  event: Fossils
+  place: 5
+- team: 27
+  event: Geologic Mapping
+  place: 2
+- team: 27
+  event: Gravity Vehicle
+  place: 14
+- team: 27
+  event: Machines
+  place: 1
+- team: 27
+  event: Ornithology
+  place: 8
+- team: 27
+  event: Ping Pong Parachute
+  place: 26
+- team: 27
+  event: Protein Modeling
+  place: 7
+- team: 27
+  event: Sounds of Music
+  place: 6
+- team: 27
+  event: Water Quality
+  place: 5
+- team: 27
+  event: Wright Stuff
+  place: 1
+- team: 27
+  event: Write It Do It
+  place: 11
+- team: 28
+  event: Anatomy and Physiology
+  place: 30
+- team: 28
+  event: Astronomy
+  place: 11
+- team: 28
+  event: Boomilever
+  place: 16
+- team: 28
+  event: Chemistry Lab
+  place: 16
+- team: 28
+  event: Circuit Lab
+  place: 35
+- team: 28
+  event: Codebusters
+  place: 7
+- team: 28
+  event: Designer Genes
+  place: 21
+- team: 28
+  event: Detector Building
+  place: 12
+- team: 28
+  event: Disease Detectives
+  place: 15
+- team: 28
+  event: Dynamic Planet
+  place: 12
+- team: 28
+  event: Experimental Design
+  place: 13
+- team: 28
+  event: Forensics
+  place: 13
+- team: 28
+  event: Fossils
+  place: 8
+- team: 28
+  event: Geologic Mapping
+  place: 25
+- team: 28
+  event: Gravity Vehicle
+  place: 22
+- team: 28
+  event: Machines
+  place: 15
+- team: 28
+  event: Ornithology
+  place: 22
+- team: 28
+  event: Ping Pong Parachute
+  place: 7
+- team: 28
+  event: Protein Modeling
+  place: 17
+- team: 28
+  event: Sounds of Music
+  place: 18
+- team: 28
+  event: Water Quality
+  place: 16
+- team: 28
+  event: Wright Stuff
+  participated: true
+- team: 28
+  event: Write It Do It
+  place: 27
+- team: 29
+  event: Anatomy and Physiology
+  place: 9
+- team: 29
+  event: Astronomy
+  place: 24
+- team: 29
+  event: Boomilever
+  participated: false
+- team: 29
+  event: Chemistry Lab
+  place: 7
+- team: 29
+  event: Circuit Lab
+  place: 17
+- team: 29
+  event: Codebusters
+  place: 19
+- team: 29
+  event: Designer Genes
+  place: 24
+- team: 29
+  event: Detector Building
+  participated: false
+- team: 29
+  event: Disease Detectives
+  place: 24
+- team: 29
+  event: Dynamic Planet
+  participated: false
+- team: 29
+  event: Experimental Design
+  participated: false
+- team: 29
+  event: Forensics
+  place: 17
+- team: 29
+  event: Fossils
+  participated: false
+- team: 29
+  event: Geologic Mapping
+  participated: false
+- team: 29
+  event: Gravity Vehicle
+  participated: false
+- team: 29
+  event: Machines
+  participated: false
+- team: 29
+  event: Ornithology
+  place: 4
+- team: 29
+  event: Ping Pong Parachute
+  participated: false
+- team: 29
+  event: Protein Modeling
+  place: 18
+- team: 29
+  event: Sounds of Music
+  participated: false
+- team: 29
+  event: Water Quality
+  place: 20
+- team: 29
+  event: Wright Stuff
+  participated: false
+- team: 29
+  event: Write It Do It
+  participated: false
+- team: 30
+  event: Anatomy and Physiology
+  participated: false
+- team: 30
+  event: Astronomy
+  participated: false
+- team: 30
+  event: Boomilever
+  place: 30
+- team: 30
+  event: Chemistry Lab
+  participated: false
+- team: 30
+  event: Circuit Lab
+  participated: false
+- team: 30
+  event: Codebusters
+  participated: false
+- team: 30
+  event: Designer Genes
+  participated: false
+- team: 30
+  event: Detector Building
+  place: 17
+- team: 30
+  event: Disease Detectives
+  participated: false
+- team: 30
+  event: Dynamic Planet
+  participated: false
+- team: 30
+  event: Experimental Design
+  participated: false
+- team: 30
+  event: Forensics
+  participated: false
+- team: 30
+  event: Fossils
+  participated: false
+- team: 30
+  event: Geologic Mapping
+  participated: false
+- team: 30
+  event: Gravity Vehicle
+  participated: false
+- team: 30
+  event: Machines
+  participated: false
+- team: 30
+  event: Ornithology
+  participated: false
+- team: 30
+  event: Ping Pong Parachute
+  participated: false
+- team: 30
+  event: Protein Modeling
+  participated: false
+- team: 30
+  event: Sounds of Music
+  participated: false
+- team: 30
+  event: Water Quality
+  participated: false
+- team: 30
+  event: Wright Stuff
+  participated: false
+- team: 30
+  event: Write It Do It
+  participated: false
+- team: 31
+  event: Anatomy and Physiology
+  place: 8
+- team: 31
+  event: Astronomy
+  place: 28
+- team: 31
+  event: Boomilever
+  place: 17
+- team: 31
+  event: Chemistry Lab
+  place: 23
+- team: 31
+  event: Circuit Lab
+  place: 10
+- team: 31
+  event: Codebusters
+  place: 16
+- team: 31
+  event: Designer Genes
+  place: 5
+- team: 31
+  event: Detector Building
+  place: 18
+- team: 31
+  event: Disease Detectives
+  place: 18
+- team: 31
+  event: Dynamic Planet
+  place: 17
+- team: 31
+  event: Experimental Design
+  place: 26
+- team: 31
+  event: Forensics
+  participated: false
+- team: 31
+  event: Fossils
+  place: 12
+- team: 31
+  event: Geologic Mapping
+  place: 23
+- team: 31
+  event: Gravity Vehicle
+  place: 11
+- team: 31
+  event: Machines
+  place: 10
+- team: 31
+  event: Ornithology
+  place: 30
+- team: 31
+  event: Ping Pong Parachute
+  place: 15
+- team: 31
+  event: Protein Modeling
+  place: 27
+- team: 31
+  event: Sounds of Music
+  place: 22
+- team: 31
+  event: Water Quality
+  place: 25
+- team: 31
+  event: Wright Stuff
+  participated: false
+- team: 31
+  event: Write It Do It
+  place: 7
+- team: 32
+  event: Anatomy and Physiology
+  place: 13
+- team: 32
+  event: Astronomy
+  participated: false
+- team: 32
+  event: Boomilever
+  participated: false
+- team: 32
+  event: Chemistry Lab
+  place: 21
+- team: 32
+  event: Circuit Lab
+  place: 33
+- team: 32
+  event: Codebusters
+  place: 17
+- team: 32
+  event: Designer Genes
+  participated: false
+- team: 32
+  event: Detector Building
+  participated: false
+- team: 32
+  event: Disease Detectives
+  participated: false
+- team: 32
+  event: Dynamic Planet
+  participated: false
+- team: 32
+  event: Experimental Design
+  participated: false
+- team: 32
+  event: Forensics
+  place: 9
+- team: 32
+  event: Fossils
+  participated: false
+- team: 32
+  event: Geologic Mapping
+  participated: false
+- team: 32
+  event: Gravity Vehicle
+  participated: false
+- team: 32
+  event: Machines
+  participated: false
+- team: 32
+  event: Ornithology
+  participated: false
+- team: 32
+  event: Ping Pong Parachute
+  participated: false
+- team: 32
+  event: Protein Modeling
+  participated: false
+- team: 32
+  event: Sounds of Music
+  place: 30
+- team: 32
+  event: Water Quality
+  participated: false
+- team: 32
+  event: Wright Stuff
+  participated: false
+- team: 32
+  event: Write It Do It
+  participated: false
+- team: 33
+  event: Anatomy and Physiology
+  participated: false
+- team: 33
+  event: Astronomy
+  participated: false
+- team: 33
+  event: Boomilever
+  place: 15
+- team: 33
+  event: Chemistry Lab
+  participated: false
+- team: 33
+  event: Circuit Lab
+  participated: false
+- team: 33
+  event: Codebusters
+  participated: false
+- team: 33
+  event: Designer Genes
+  participated: false
+- team: 33
+  event: Detector Building
+  participated: false
+- team: 33
+  event: Disease Detectives
+  participated: false
+- team: 33
+  event: Dynamic Planet
+  participated: false
+- team: 33
+  event: Experimental Design
+  place: 18
+- team: 33
+  event: Forensics
+  participated: false
+- team: 33
+  event: Fossils
+  participated: false
+- team: 33
+  event: Geologic Mapping
+  participated: false
+- team: 33
+  event: Gravity Vehicle
+  place: 25
+- team: 33
+  event: Machines
+  place: 23
+- team: 33
+  event: Ornithology
+  participated: false
+- team: 33
+  event: Ping Pong Parachute
+  place: 13
+- team: 33
+  event: Protein Modeling
+  participated: false
+- team: 33
+  event: Sounds of Music
+  place: 15
+- team: 33
+  event: Water Quality
+  participated: false
+- team: 33
+  event: Wright Stuff
+  place: 14
+- team: 33
+  event: Write It Do It
+  place: 28
+- team: 34
+  event: Anatomy and Physiology
+  place: 16
+- team: 34
+  event: Astronomy
+  place: 27
+- team: 34
+  event: Boomilever
+  place: 21
+- team: 34
+  event: Chemistry Lab
+  place: 14
+- team: 34
+  event: Circuit Lab
+  place: 11
+- team: 34
+  event: Codebusters
+  place: 29
+- team: 34
+  event: Designer Genes
+  place: 11
+- team: 34
+  event: Detector Building
+  participated: false
+- team: 34
+  event: Disease Detectives
+  place: 31
+- team: 34
+  event: Dynamic Planet
+  place: 30
+- team: 34
+  event: Experimental Design
+  place: 27
+- team: 34
+  event: Forensics
+  participated: false
+- team: 34
+  event: Fossils
+  place: 24
+- team: 34
+  event: Geologic Mapping
+  participated: false
+- team: 34
+  event: Gravity Vehicle
+  participated: false
+- team: 34
+  event: Machines
+  place: 16
+- team: 34
+  event: Ornithology
+  place: 28
+- team: 34
+  event: Ping Pong Parachute
+  place: 25
+- team: 34
+  event: Protein Modeling
+  place: 8
+- team: 34
+  event: Sounds of Music
+  participated: false
+- team: 34
+  event: Water Quality
+  place: 28
+- team: 34
+  event: Wright Stuff
+  place: 26
+- team: 34
+  event: Write It Do It
+  place: 18
+- team: 35
+  event: Anatomy and Physiology
+  place: 23
+- team: 35
+  event: Astronomy
+  participated: false
+- team: 35
+  event: Boomilever
+  place: 20
+- team: 35
+  event: Chemistry Lab
+  participated: false
+- team: 35
+  event: Circuit Lab
+  place: 27
+- team: 35
+  event: Codebusters
+  place: 32
+- team: 35
+  event: Designer Genes
+  participated: false
+- team: 35
+  event: Detector Building
+  participated: false
+- team: 35
+  event: Disease Detectives
+  place: 17
+- team: 35
+  event: Dynamic Planet
+  participated: false
+- team: 35
+  event: Experimental Design
+  participated: false
+- team: 35
+  event: Forensics
+  participated: false
+- team: 35
+  event: Fossils
+  place: 21
+- team: 35
+  event: Geologic Mapping
+  participated: false
+- team: 35
+  event: Gravity Vehicle
+  participated: false
+- team: 35
+  event: Machines
+  participated: false
+- team: 35
+  event: Ornithology
+  place: 11
+- team: 35
+  event: Ping Pong Parachute
+  participated: false
+- team: 35
+  event: Protein Modeling
+  participated: false
+- team: 35
+  event: Sounds of Music
+  place: 24
+- team: 35
+  event: Water Quality
+  place: 26
+- team: 35
+  event: Wright Stuff
+  participated: false
+- team: 35
+  event: Write It Do It
+  place: 30
+- team: 36
+  event: Anatomy and Physiology
+  place: 27
+- team: 36
+  event: Astronomy
+  place: 3
+- team: 36
+  event: Boomilever
+  participated: false
+- team: 36
+  event: Chemistry Lab
+  place: 25
+- team: 36
+  event: Circuit Lab
+  place: 30
+- team: 36
+  event: Codebusters
+  place: 23
+- team: 36
+  event: Designer Genes
+  place: 23
+- team: 36
+  event: Detector Building
+  place: 14
+- team: 36
+  event: Disease Detectives
+  place: 7
+- team: 36
+  event: Dynamic Planet
+  place: 16
+- team: 36
+  event: Experimental Design
+  place: 31
+- team: 36
+  event: Forensics
+  place: 16
+- team: 36
+  event: Fossils
+  place: 27
+- team: 36
+  event: Geologic Mapping
+  participated: false
+- team: 36
+  event: Gravity Vehicle
+  place: 23
+- team: 36
+  event: Machines
+  participated: false
+- team: 36
+  event: Ornithology
+  participated: false
+- team: 36
+  event: Ping Pong Parachute
+  place: 20
+- team: 36
+  event: Protein Modeling
+  place: 26
+- team: 36
+  event: Sounds of Music
+  participated: false
+- team: 36
+  event: Water Quality
+  place: 8
+- team: 36
+  event: Wright Stuff
+  participated: false
+- team: 36
+  event: Write It Do It
+  place: 5
+- team: 37
+  event: Anatomy and Physiology
+  place: 21
+- team: 37
+  event: Astronomy
+  participated: false
+- team: 37
+  event: Boomilever
+  place: 19
+- team: 37
+  event: Chemistry Lab
+  place: 20
+- team: 37
+  event: Circuit Lab
+  place: 32
+- team: 37
+  event: Codebusters
+  participated: false
+- team: 37
+  event: Designer Genes
+  participated: false
+- team: 37
+  event: Detector Building
+  participated: false
+- team: 37
+  event: Disease Detectives
+  participated: false
+- team: 37
+  event: Dynamic Planet
+  participated: false
+- team: 37
+  event: Experimental Design
+  participated: false
+- team: 37
+  event: Forensics
+  participated: false
+- team: 37
+  event: Fossils
+  participated: false
+- team: 37
+  event: Geologic Mapping
+  participated: false
+- team: 37
+  event: Gravity Vehicle
+  place: 12
+- team: 37
+  event: Machines
+  participated: false
+- team: 37
+  event: Ornithology
+  participated: false
+- team: 37
+  event: Ping Pong Parachute
+  place: 22
+- team: 37
+  event: Protein Modeling
+  participated: false
+- team: 37
+  event: Sounds of Music
+  place: 17
+- team: 37
+  event: Water Quality
+  place: 12
+- team: 37
+  event: Wright Stuff
+  participated: false
+- team: 37
+  event: Write It Do It
+  place: 16
+- team: 38
+  event: Anatomy and Physiology
+  place: 25
+- team: 38
+  event: Astronomy
+  place: 29
+- team: 38
+  event: Boomilever
+  place: 23
+- team: 38
+  event: Chemistry Lab
+  place: 1
+- team: 38
+  event: Circuit Lab
+  place: 2
+- team: 38
+  event: Codebusters
+  place: 26
+- team: 38
+  event: Designer Genes
+  place: 31
+- team: 38
+  event: Detector Building
+  participated: false
+- team: 38
+  event: Disease Detectives
+  place: 25
+- team: 38
+  event: Dynamic Planet
+  place: 31
+- team: 38
+  event: Experimental Design
+  place: 25
+- team: 38
+  event: Forensics
+  place: 10
+- team: 38
+  event: Fossils
+  place: 29
+- team: 38
+  event: Geologic Mapping
+  place: 22
+- team: 38
+  event: Gravity Vehicle
+  participated: false
+- team: 38
+  event: Machines
+  place: 22
+- team: 38
+  event: Ornithology
+  place: 13
+- team: 38
+  event: Ping Pong Parachute
+  place: 24
+- team: 38
+  event: Protein Modeling
+  place: 19
+- team: 38
+  event: Sounds of Music
+  place: 19
+- team: 38
+  event: Water Quality
+  place: 14
+- team: 38
+  event: Wright Stuff
+  place: 13
+- team: 38
+  event: Write It Do It
+  place: 26
+- team: 39
+  event: Anatomy and Physiology
+  participated: false
+- team: 39
+  event: Astronomy
+  participated: false
+- team: 39
+  event: Boomilever
+  place: 27
+- team: 39
+  event: Chemistry Lab
+  participated: false
+- team: 39
+  event: Circuit Lab
+  place: 3
+- team: 39
+  event: Codebusters
+  place: 34
+- team: 39
+  event: Designer Genes
+  participated: false
+- team: 39
+  event: Detector Building
+  participated: false
+- team: 39
+  event: Disease Detectives
+  participated: false
+- team: 39
+  event: Dynamic Planet
+  participated: false
+- team: 39
+  event: Experimental Design
+  participated: false
+- team: 39
+  event: Forensics
+  participated: false
+- team: 39
+  event: Fossils
+  participated: false
+- team: 39
+  event: Geologic Mapping
+  participated: false
+- team: 39
+  event: Gravity Vehicle
+  place: 18
+- team: 39
+  event: Machines
+  participated: false
+- team: 39
+  event: Ornithology
+  place: 27
+- team: 39
+  event: Ping Pong Parachute
+  place: 21
+- team: 39
+  event: Protein Modeling
+  participated: false
+- team: 39
+  event: Sounds of Music
+  participated: false
+- team: 39
+  event: Water Quality
+  participated: false
+- team: 39
+  event: Wright Stuff
+  participated: false
+- team: 39
+  event: Write It Do It
+  participated: false

--- a/data/2020-02-29_nCA_bay_area_regional_c.yaml
+++ b/data/2020-02-29_nCA_bay_area_regional_c.yaml
@@ -1,6 +1,7 @@
 ---
 Tournament:
   name: Bay Area Regional Science Olympiad Tournament
+  short name: BARSO
   location: California State University East Bay
   state: nCA
   level: Regionals
@@ -174,10 +175,12 @@ Teams:
 - number: 38
   school: California High School
   suffix: Orange
+  city: San Ramon
   state: CA
 - number: 39
   school: California High School
   suffix: Black
+  city: San Ramon
   state: CA
 Placings:
 - team: 1


### PR DESCRIPTION
Here's the results for Bay Area Regionals for Div B and C.
Ping Pong Parachute was medal only due to the wind.